### PR TITLE
Upgrade all packages and use latest nodejs version

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,31 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 17.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: yarn
+    - run: yarn test
+

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
     "name": "stromjs",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "description": "Dependency-free streams utils for Node.js",
     "keywords": [
         "promise",
         "stream",
         "utils"
     ],
+    "engines": {
+        "node": ">=16.0.0"
+    },
     "contributors": [
         {
             "name": "Sami Turcotte",
@@ -42,20 +45,20 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "@ava/typescript": "^1.1.1",
-        "@types/chai": "^4.2.14",
-        "@types/node": "^14.14.25",
-        "@types/sinon": "^9.0.10",
-        "ava": "^3.15.0",
-        "chai": "^4.3.0",
-        "prettier": "^2.2.1",
-        "sinon": "^9.2.4",
+        "@ava/typescript": "^3.0.1",
+        "@types/chai": "^4.3.0",
+        "@types/node": "^17.0.17",
+        "@types/sinon": "^10.0.11",
+        "ava": "^4.0.1",
+        "chai": "^4.3.6",
+        "prettier": "^2.5.1",
+        "sinon": "^13.0.1",
         "stromjs": "./",
-        "ts-node": "^9.1.1",
+        "ts-node": "^10.5.0",
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.16.0",
         "tslint-plugin-prettier": "^2.3.0",
-        "typescript": "^4.1.3"
+        "typescript": "^4.5.5"
     },
     "ava": {
         "files": [

--- a/src/functions/accumulator.ts
+++ b/src/functions/accumulator.ts
@@ -16,8 +16,12 @@ function _accumulator<T>(
     return new Transform({
         ...options,
         transform(data: T, encoding, callback) {
-            accumulateBy(data, buffer, this);
-            callback();
+            try {
+                accumulateBy(data, buffer, this);
+                callback();
+            } catch (err) {
+                callback(err);
+            }
         },
         flush(callback) {
             if (shouldFlush) {

--- a/src/functions/filter.ts
+++ b/src/functions/filter.ts
@@ -9,11 +9,15 @@ export function filter<T>(
     return new Transform({
         ...options,
         async transform(chunk: T, encoding?: any, callback?: any) {
-            const result = await predicate(chunk, encoding);
-            if (result === true) {
-                callback(null, chunk);
-            } else {
-                callback();
+            try {
+                const result = await predicate(chunk, encoding);
+                if (result === true) {
+                    callback(null, chunk);
+                } else {
+                    callback();
+                }
+            } catch (err) {
+                callback(err);
             }
         },
     });

--- a/src/functions/flatMap.ts
+++ b/src/functions/flatMap.ts
@@ -9,8 +9,12 @@ export function flatMap<T, R>(
     return new Transform({
         ...options,
         async transform(chunk: T, encoding, callback) {
-            (await mapper(chunk, encoding)).forEach((c) => this.push(c));
-            callback();
+            try {
+                (await mapper(chunk, encoding)).forEach((c) => this.push(c));
+                callback();
+            } catch (err) {
+                callback(err);
+            }
         },
     });
 }

--- a/src/functions/reduce.ts
+++ b/src/functions/reduce.ts
@@ -11,8 +11,12 @@ export function reduce<T, R>(
     return new Transform({
         ...options,
         async transform(chunk: T, encoding, callback) {
-            value = await iteratee(value, chunk, encoding);
-            callback();
+            try {
+                value = await iteratee(value, chunk, encoding);
+                callback();
+            } catch (err) {
+                callback(err);
+            }
         },
         flush(callback) {
             // Best effort attempt at yielding the final value (will throw if e.g. yielding an object and

--- a/src/functions/split.ts
+++ b/src/functions/split.ts
@@ -1,10 +1,13 @@
-import { Transform } from "stream";
+import { Transform, TransformOptions } from "stream";
 import { StringDecoder } from "string_decoder";
 import { WithEncoding } from "./baseDefinitions";
 
 export function split(
     separator: string | RegExp = "\n",
-    options: WithEncoding = { encoding: "utf8" },
+    options: WithEncoding & TransformOptions = {
+        encoding: "utf8",
+        objectMode: true,
+    },
 ): Transform {
     let buffered = "";
     const decoder = new StringDecoder(options.encoding);
@@ -13,13 +16,13 @@ export function split(
         readableObjectMode: true,
         transform(chunk: Buffer, encoding, callback) {
             const asString = decoder.write(chunk);
-            const splitted = asString.split(separator);
-            if (splitted.length > 1) {
-                splitted[0] = buffered.concat(splitted[0]);
+            const split = asString.split(separator);
+            if (split.length > 1) {
+                split[0] = buffered.concat(split[0]);
                 buffered = "";
             }
-            buffered += splitted[splitted.length - 1];
-            splitted.slice(0, -1).forEach((part: string) => this.push(part));
+            buffered += split[split.length - 1];
+            split.slice(0, -1).forEach((part: string) => this.push(part));
             callback();
         },
         flush(callback) {

--- a/tests/accumulator.spec.ts
+++ b/tests/accumulator.spec.ts
@@ -5,7 +5,7 @@ import { accumulator, accumulatorBy } from "../src";
 import { FlushStrategy } from "../src/functions/accumulator";
 import { performance } from "perf_hooks";
 
-test.cb("accumulator() rolling", t => {
+test("accumulator() rolling", (t) => {
     t.plan(3);
     let chunkIndex = 0;
     interface TestObject {
@@ -24,27 +24,29 @@ test.cb("accumulator() rolling", t => {
     const thirdFlush = [{ ts: 4, key: "f" }];
     const flushes = [firstFlush, secondFlush, thirdFlush];
 
-    source
-        .pipe(
-            accumulator(FlushStrategy.rolling, 2, undefined, {
-                objectMode: true,
-            }),
-        )
-        .on("data", (flush: TestObject[]) => {
-            t.deepEqual(flush, flushes[chunkIndex]);
-            chunkIndex++;
-        })
-        .on("error", (e: any) => {
-            t.end(e);
-        })
-        .on("end", t.end);
-    [...firstFlush, ...secondFlush, ...thirdFlush].forEach(item => {
-        source.push(item);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(
+                accumulator(FlushStrategy.rolling, 2, undefined, {
+                    objectMode: true,
+                }),
+            )
+            .on("data", (flush: TestObject[]) => {
+                t.deepEqual(flush, flushes[chunkIndex]);
+                chunkIndex++;
+            })
+            .on("error", (e: any) => {
+                reject(e);
+            })
+            .on("end", resolve);
+        [...firstFlush, ...secondFlush, ...thirdFlush].forEach((item) => {
+            source.push(item);
+        });
+        source.push(null);
     });
-    source.push(null);
 });
 
-test.cb("accumulator() rolling with key", t => {
+test("accumulator() rolling with key", (t) => {
     t.plan(2);
     let chunkIndex = 0;
     interface TestObject {
@@ -61,43 +63,48 @@ test.cb("accumulator() rolling with key", t => {
     const secondFlush = [{ ts: 3, key: "e" }];
     const flushes = [firstFlush, secondFlush];
 
-    source
-        .pipe(accumulator(FlushStrategy.rolling, 3, "ts", { objectMode: true }))
-        .on("data", (flush: TestObject[]) => {
-            t.deepEqual(flush, flushes[chunkIndex]);
-            chunkIndex++;
-        })
-        .on("error", (e: any) => {
-            t.end(e);
-        })
-        .on("end", t.end);
-    [...firstFlush, ...secondFlush].forEach(item => {
-        source.push(item);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(
+                accumulator(FlushStrategy.rolling, 3, "ts", {
+                    objectMode: true,
+                }),
+            )
+            .on("data", (flush: TestObject[]) => {
+                t.deepEqual(flush, flushes[chunkIndex]);
+                chunkIndex++;
+            })
+            .on("error", (e: any) => {
+                reject(e);
+            })
+            .on("end", resolve);
+        [...firstFlush, ...secondFlush].forEach((item) => {
+            source.push(item);
+        });
+        source.push(null);
     });
-    source.push(null);
 });
 
-test.cb(
-    "accumulator() rolling should emit error and ignore chunk when its missing key",
-    t => {
-        t.plan(2);
-        let index = 0;
-        interface TestObject {
-            ts: number;
-            key: string;
-        }
-        const source = new Readable({ objectMode: true });
-        const accumulatorStream = accumulator(
-            FlushStrategy.rolling,
-            3,
-            "nonExistingKey",
-            { objectMode: true },
-        );
-        const input = [
-            { ts: 0, key: "a" },
-            { ts: 1, key: "b" },
-        ];
+test("accumulator() rolling should emit error and ignore chunk when its missing key", (t) => {
+    t.plan(2);
+    let index = 0;
+    interface TestObject {
+        ts: number;
+        key: string;
+    }
+    const source = new Readable({ objectMode: true });
+    const accumulatorStream = accumulator(
+        FlushStrategy.rolling,
+        3,
+        "nonExistingKey",
+        { objectMode: true },
+    );
+    const input = [
+        { ts: 0, key: "a" },
+        { ts: 1, key: "b" },
+    ];
 
+    return new Promise((resolve, reject) => {
         source
             .pipe(accumulatorStream)
             .on("data", (flush: TestObject[]) => {
@@ -115,42 +122,41 @@ test.cb(
                 index++;
                 t.pass();
             })
-            .on("end", t.end);
-        input.forEach(item => {
+            .on("end", resolve);
+        input.forEach((item) => {
             source.push(item);
         });
         source.push(null);
-    },
-);
+    });
+});
 
-test.cb(
-    "accumulator() rolling should emit error, ignore chunk when key is missing and continue processing chunks correctly",
-    t => {
-        t.plan(3);
-        let chunkIndex = 0;
-        interface TestObject {
-            ts: number;
-            key: string;
-        }
-        const source = new Readable({ objectMode: true });
-        const accumulatorStream = accumulator(FlushStrategy.rolling, 3, "ts", {
-            objectMode: true,
-        });
-        const input = [
-            { ts: 0, key: "a" },
-            { ts: 1, key: "b" },
-            { ts: 2, key: "c" },
-            { key: "d" },
-            { ts: 3, key: "e" },
-        ];
-        const firstFlush = [
-            { ts: 0, key: "a" },
-            { ts: 1, key: "b" },
-            { ts: 2, key: "c" },
-        ];
-        const secondFlush = [{ ts: 3, key: "e" }];
-        const flushes = [firstFlush, secondFlush];
+test("accumulator() rolling should emit error, ignore chunk when key is missing and continue processing chunks correctly", (t) => {
+    t.plan(3);
+    let chunkIndex = 0;
+    interface TestObject {
+        ts: number;
+        key: string;
+    }
+    const source = new Readable({ objectMode: true });
+    const accumulatorStream = accumulator(FlushStrategy.rolling, 3, "ts", {
+        objectMode: true,
+    });
+    const input = [
+        { ts: 0, key: "a" },
+        { ts: 1, key: "b" },
+        { ts: 2, key: "c" },
+        { key: "d" },
+        { ts: 3, key: "e" },
+    ];
+    const firstFlush = [
+        { ts: 0, key: "a" },
+        { ts: 1, key: "b" },
+        { ts: 2, key: "c" },
+    ];
+    const secondFlush = [{ ts: 3, key: "e" }];
+    const flushes = [firstFlush, secondFlush];
 
+    return new Promise((resolve, reject) => {
         source
             .pipe(accumulatorStream)
             .on("data", (flush: TestObject[]) => {
@@ -167,15 +173,15 @@ test.cb(
                 );
                 t.pass();
             })
-            .on("end", t.end);
-        input.forEach(item => {
+            .on("end", resolve);
+        input.forEach((item) => {
             source.push(item);
         });
         source.push(null);
-    },
-);
+    });
+});
 
-test.cb("accumulator() sliding", t => {
+test("accumulator() sliding", (t) => {
     t.plan(4);
     let chunkIndex = 0;
     interface TestObject {
@@ -206,27 +212,27 @@ test.cb("accumulator() sliding", t => {
     ];
 
     const flushes = [firstFlush, secondFlush, thirdFlush, fourthFlush];
-    source
-        .pipe(
-            accumulator(FlushStrategy.sliding, 3, undefined, {
-                objectMode: true,
-            }),
-        )
-        .on("data", (flush: TestObject[]) => {
-            t.deepEqual(flush, flushes[chunkIndex]);
-            chunkIndex++;
-        })
-        .on("error", (e: any) => {
-            t.end(e);
-        })
-        .on("end", t.end);
-    input.forEach(item => {
-        source.push(item);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(
+                accumulator(FlushStrategy.sliding, 3, undefined, {
+                    objectMode: true,
+                }),
+            )
+            .on("data", (flush: TestObject[]) => {
+                t.deepEqual(flush, flushes[chunkIndex]);
+                chunkIndex++;
+            })
+            .on("error", reject)
+            .on("end", resolve);
+        input.forEach((item) => {
+            source.push(item);
+        });
+        source.push(null);
     });
-    source.push(null);
 });
 
-test.cb("accumulator() sliding with key", t => {
+test("accumulator() sliding with key", (t) => {
     t.plan(6);
     let chunkIndex = 0;
     interface TestObject {
@@ -274,43 +280,45 @@ test.cb("accumulator() sliding with key", t => {
         fifthFlush,
         sixthFlush,
     ];
-    source
-        .pipe(accumulator(FlushStrategy.sliding, 3, "ts", { objectMode: true }))
-        .on("data", (flush: TestObject[]) => {
-            t.deepEqual(flush, flushes[chunkIndex]);
-            chunkIndex++;
-        })
-        .on("error", (e: any) => {
-            t.end(e);
-        })
-        .on("end", t.end);
-    input.forEach(item => {
-        source.push(item);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(
+                accumulator(FlushStrategy.sliding, 3, "ts", {
+                    objectMode: true,
+                }),
+            )
+            .on("data", (flush: TestObject[]) => {
+                t.deepEqual(flush, flushes[chunkIndex]);
+                chunkIndex++;
+            })
+            .on("error", reject)
+            .on("end", resolve);
+        input.forEach((item) => {
+            source.push(item);
+        });
+        source.push(null);
     });
-    source.push(null);
 });
 
-test.cb(
-    "accumulator() sliding should emit error and ignore chunk when key is missing",
-    t => {
-        t.plan(2);
-        let index = 0;
-        interface TestObject {
-            ts: number;
-            key: string;
-        }
-        const source = new Readable({ objectMode: true });
-        const accumulatorStream = accumulator(
-            FlushStrategy.sliding,
-            3,
-            "nonExistingKey",
-            { objectMode: true },
-        );
-        const input = [
-            { ts: 0, key: "a" },
-            { ts: 1, key: "b" },
-        ];
-
+test("accumulator() sliding should emit error and ignore chunk when key is missing", (t) => {
+    t.plan(2);
+    let index = 0;
+    interface TestObject {
+        ts: number;
+        key: string;
+    }
+    const source = new Readable({ objectMode: true });
+    const accumulatorStream = accumulator(
+        FlushStrategy.sliding,
+        3,
+        "nonExistingKey",
+        { objectMode: true },
+    );
+    const input = [
+        { ts: 0, key: "a" },
+        { ts: 1, key: "b" },
+    ];
+    return new Promise((resolve, reject) => {
         source
             .pipe(accumulatorStream)
             .on("data", (flush: TestObject[]) => {
@@ -327,60 +335,59 @@ test.cb(
                 index++;
                 t.pass();
             })
-            .on("end", t.end);
-        input.forEach(item => {
+            .on("end", resolve);
+        input.forEach((item) => {
             source.push(item);
         });
         source.push(null);
-    },
-);
+    });
+});
 
-test.cb(
-    "accumulator() sliding should emit error, ignore chunk when key is missing and continue processing chunks correctly",
-    t => {
-        t.plan(6);
-        let chunkIndex = 0;
-        interface TestObject {
-            ts: number;
-            key: string;
-        }
-        const source = new Readable({ objectMode: true });
-        const accumulatorStream = accumulator(FlushStrategy.sliding, 3, "ts", {
-            objectMode: true,
-        });
-        const input = [
-            { ts: 0, key: "a" },
-            { key: "b" },
-            { ts: 2, key: "c" },
-            { ts: 3, key: "d" },
-            { ts: 5, key: "f" },
-            { ts: 6, key: "g" },
-        ];
-        const firstFlush = [{ ts: 0, key: "a" }];
-        const secondFlush = [
-            { ts: 0, key: "a" },
-            { ts: 2, key: "c" },
-        ];
-        const thirdFlush = [
-            { ts: 2, key: "c" },
-            { ts: 3, key: "d" },
-        ];
-        const fourthFlush = [
-            { ts: 3, key: "d" },
-            { ts: 5, key: "f" },
-        ];
-        const fifthFlush = [
-            { ts: 5, key: "f" },
-            { ts: 6, key: "g" },
-        ];
+test("accumulator() sliding should emit error, ignore chunk when key is missing and continue processing chunks correctly", (t) => {
+    t.plan(6);
+    let chunkIndex = 0;
+    interface TestObject {
+        ts: number;
+        key: string;
+    }
+    const source = new Readable({ objectMode: true });
+    const accumulatorStream = accumulator(FlushStrategy.sliding, 3, "ts", {
+        objectMode: true,
+    });
+    const input = [
+        { ts: 0, key: "a" },
+        { key: "b" },
+        { ts: 2, key: "c" },
+        { ts: 3, key: "d" },
+        { ts: 5, key: "f" },
+        { ts: 6, key: "g" },
+    ];
+    const firstFlush = [{ ts: 0, key: "a" }];
+    const secondFlush = [
+        { ts: 0, key: "a" },
+        { ts: 2, key: "c" },
+    ];
+    const thirdFlush = [
+        { ts: 2, key: "c" },
+        { ts: 3, key: "d" },
+    ];
+    const fourthFlush = [
+        { ts: 3, key: "d" },
+        { ts: 5, key: "f" },
+    ];
+    const fifthFlush = [
+        { ts: 5, key: "f" },
+        { ts: 6, key: "g" },
+    ];
 
-        const flushes = [
-            firstFlush,
-            secondFlush,
-            thirdFlush,
-            fourthFlush,
-            fifthFlush,
-        ];
+    const flushes = [
+        firstFlush,
+        secondFlush,
+        thirdFlush,
+        fourthFlush,
+        fifthFlush,
+    ];
+    return new Promise((resolve, reject) => {
         source
             .pipe(accumulatorStream)
             .on("data", (flush: TestObject[]) => {
@@ -397,15 +404,15 @@ test.cb(
                 );
                 t.pass();
             })
-            .on("end", t.end);
-        input.forEach(item => {
+            .on("end", resolve);
+        input.forEach((item) => {
             source.push(item);
         });
         source.push(null);
-    },
-);
+    });
+});
 
-test.cb("accumulatorBy() rolling", t => {
+test("accumulatorBy() rolling", (t) => {
     t.plan(2);
     let chunkIndex = 0;
     interface TestObject {
@@ -422,54 +429,53 @@ test.cb("accumulatorBy() rolling", t => {
     const secondFlush = [{ ts: 3, key: "e" }];
     const flushes = [firstFlush, secondFlush];
 
-    source
-        .pipe(
-            accumulatorBy(
-                FlushStrategy.rolling,
-                (event: TestObject, bufferChunk: TestObject) => {
-                    return bufferChunk.ts + 3 <= event.ts;
-                },
-                { objectMode: true },
-            ),
-        )
-        .on("data", (flush: TestObject[]) => {
-            t.deepEqual(flush, flushes[chunkIndex]);
-            chunkIndex++;
-        })
-        .on("error", (e: any) => {
-            t.end(e);
-        })
-        .on("end", t.end);
-    [...firstFlush, ...secondFlush].forEach(item => {
-        source.push(item);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(
+                accumulatorBy(
+                    FlushStrategy.rolling,
+                    (event: TestObject, bufferChunk: TestObject) => {
+                        return bufferChunk.ts + 3 <= event.ts;
+                    },
+                    { objectMode: true },
+                ),
+            )
+            .on("data", (flush: TestObject[]) => {
+                t.deepEqual(flush, flushes[chunkIndex]);
+                chunkIndex++;
+            })
+            .on("error", reject)
+            .on("end", resolve);
+        [...firstFlush, ...secondFlush].forEach((item) => {
+            source.push(item);
+        });
+        source.push(null);
     });
-    source.push(null);
 });
 
-test.cb.skip(
-    "accumulatorBy() rolling should emit error when key iteratee throws",
-    t => {
-        t.plan(2);
-        interface TestObject {
-            ts: number;
-            key: string;
-        }
-        const source = new Readable({ objectMode: true });
-        const input = [
-            { ts: 0, key: "a" },
-            { ts: 1, key: "b" },
-            { ts: 2, key: "c" },
-        ];
-        const accumulaterStream = accumulatorBy(
-            FlushStrategy.rolling,
-            (event: TestObject, bufferChunk: TestObject) => {
-                if (event.key !== "a") {
-                    throw new Error("Failed mapping");
-                }
-                return bufferChunk.ts + 3 <= event.ts;
-            },
-            { objectMode: true },
-        );
+test("accumulatorBy() rolling should emit error when key iteratee throws", (t) => {
+    t.plan(1);
+    interface TestObject {
+        ts: number;
+        key: string;
+    }
+    const source = new Readable({ objectMode: true });
+    const input = [
+        { ts: 0, key: "a" },
+        { ts: 1, key: "b" },
+        { ts: 2, key: "c" },
+    ];
+    const accumulaterStream = accumulatorBy(
+        FlushStrategy.rolling,
+        (event: TestObject, bufferChunk: TestObject) => {
+            if (event.key !== "a") {
+                throw new Error("Failed mapping");
+            }
+            return bufferChunk.ts + 3 <= event.ts;
+        },
+        { objectMode: true },
+    );
+    return new Promise((resolve, reject) => {
         source
             .pipe(accumulaterStream)
             .on("error", (err: any) => {
@@ -478,16 +484,16 @@ test.cb.skip(
                 expect(err.message).to.equal("Failed mapping");
                 t.pass();
             })
-            .on("end", t.end);
+            .on("close", resolve);
 
-        input.forEach(item => {
+        input.forEach((item) => {
             source.push(item);
         });
         source.push(null);
-    },
-);
+    });
+});
 
-test.cb("accumulatorBy() sliding", t => {
+test("accumulatorBy() sliding", (t) => {
     t.plan(6);
     let chunkIndex = 0;
     interface TestObject {
@@ -535,67 +541,64 @@ test.cb("accumulatorBy() sliding", t => {
         fifthFlush,
         sixthFlush,
     ];
-    source
-        .pipe(
-            accumulatorBy(
-                FlushStrategy.sliding,
-                (event: TestObject, bufferChunk: TestObject) => {
-                    return bufferChunk.ts + 3 <= event.ts ? true : false;
-                },
-                { objectMode: true },
-            ),
-        )
-        .on("data", (flush: TestObject[]) => {
-            t.deepEqual(flush, flushes[chunkIndex]);
-            chunkIndex++;
-        })
-        .on("error", (e: any) => {
-            t.end(e);
-        })
-        .on("end", t.end);
-    input.forEach(item => {
-        source.push(item);
-    });
-    source.push(null);
-});
-
-test.cb.skip(
-    "accumulatorBy() sliding should emit error when key iteratee throws",
-    t => {
-        t.plan(2);
-        interface TestObject {
-            ts: number;
-            key: string;
-        }
-        const source = new Readable({ objectMode: true });
-        const input = [
-            { ts: 0, key: "a" },
-            { ts: 1, key: "b" },
-            { ts: 2, key: "c" },
-        ];
-        const accumulaterStream = accumulatorBy(
-            FlushStrategy.sliding,
-            (event: TestObject, bufferChunk: TestObject) => {
-                if (event.key !== "a") {
-                    throw new Error("Failed mapping");
-                }
-                return bufferChunk.ts + 3 <= event.ts ? true : false;
-            },
-            { objectMode: true },
-        );
+    return new Promise((resolve, reject) => {
         source
-            .pipe(accumulaterStream)
-            .on("error", (err: any) => {
-                source.pipe(accumulaterStream);
-                accumulaterStream.resume();
-                expect(err.message).to.equal("Failed mapping");
-                t.pass();
+            .pipe(
+                accumulatorBy(
+                    FlushStrategy.sliding,
+                    (event: TestObject, bufferChunk: TestObject) => {
+                        return bufferChunk.ts + 3 <= event.ts ? true : false;
+                    },
+                    { objectMode: true },
+                ),
+            )
+            .on("data", (flush: TestObject[]) => {
+                t.deepEqual(flush, flushes[chunkIndex]);
+                chunkIndex++;
             })
-            .on("end", t.end);
-
-        input.forEach(item => {
+            .on("error", reject)
+            .on("end", resolve);
+        input.forEach((item) => {
             source.push(item);
         });
         source.push(null);
-    },
-);
+    });
+});
+
+test("accumulatorBy() sliding should emit error when key iteratee throws", (t) => {
+    t.plan(1);
+    interface TestObject {
+        ts: number;
+        key: string;
+    }
+    const source = new Readable({ objectMode: true });
+    const input = [
+        { ts: 0, key: "a" },
+        { ts: 1, key: "b" },
+        { ts: 2, key: "c" },
+    ];
+    const accumulatorStream = accumulatorBy(
+        FlushStrategy.sliding,
+        (event: TestObject, bufferChunk: TestObject) => {
+            if (event.key !== "a") {
+                throw new Error("Failed mapping");
+            }
+            return bufferChunk.ts + 3 <= event.ts ? true : false;
+        },
+        { objectMode: true },
+    );
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(accumulatorStream)
+            .on("error", (err: any) => {
+                expect(err.message).to.equal("Failed mapping");
+                t.pass();
+            })
+            .on("close", resolve);
+
+        input.forEach((item) => {
+            source.push(item);
+        });
+        source.push(null);
+    });
+});

--- a/tests/child.spec.ts
+++ b/tests/child.spec.ts
@@ -4,25 +4,24 @@ import test from "ava";
 import { expect } from "chai";
 import { child } from "../src";
 
-test.cb(
-    "child() allows easily writing to child process stdin and reading from its stdout",
-    t => {
-        t.plan(1);
-        const source = new Readable();
-        const catProcess = cp.exec("cat");
-        let out = "";
+test("child() allows easily writing to child process stdin and reading from its stdout", (t) => {
+    t.plan(1);
+    const source = new Readable();
+    const catProcess = cp.exec("cat");
+    let out = "";
+    return new Promise((resolve, reject) => {
         source
             .pipe(child(catProcess))
-            .on("data", chunk => (out += chunk))
-            .on("error", t.end)
+            .on("data", (chunk) => (out += chunk))
+            .on("error", reject)
             .on("end", () => {
                 expect(out).to.equal("abcdef");
                 t.pass();
-                t.end();
+                resolve();
             });
         source.push("ab");
         source.push("cd");
         source.push("ef");
         source.push(null);
-    },
-);
+    });
+});

--- a/tests/collect.spec.ts
+++ b/tests/collect.spec.ts
@@ -3,130 +3,114 @@ import test from "ava";
 import { expect } from "chai";
 import { collect } from "../src";
 
-test.cb(
-    "collect() collects streamed elements into an array (object, flowing mode)",
-    t => {
-        t.plan(1);
-        const source = new Readable({ objectMode: true });
-
+test("collect() collects streamed elements into an array (object, flowing mode)", (t) => {
+    t.plan(1);
+    const source = new Readable({ objectMode: true, read: () => {} });
+    return new Promise((resolve, reject) => {
         source
             .pipe(collect({ objectMode: true }))
-            .on("data", collected => {
+            .on("data", (collected) => {
                 expect(collected).to.deep.equal(["a", "b", "c"]);
                 t.pass();
             })
-            .on("error", t.end)
-            .on("end", t.end);
+            .on("error", reject)
+            .on("end", resolve);
 
         source.push("a");
         source.push("b");
         source.push("c");
         source.push(null);
-    },
-);
+    });
+});
 
-test.cb(
-    "collect() collects streamed elements into an array (object, paused mode)",
-    t => {
-        t.plan(1);
-        const source = new Readable({ objectMode: true });
-        const collector = source.pipe(collect({ objectMode: true }));
+test("collect() collects streamed elements into an array (object, paused mode)", (t) => {
+    t.plan(1);
+    const source = new Readable({ objectMode: true, read: () => {} });
+    const collector = source.pipe(collect({ objectMode: true }));
 
+    return new Promise((resolve, reject) => {
         collector
-            .on("readable", () => {
-                let collected = collector.read();
-                while (collected !== null) {
-                    expect(collected).to.deep.equal(["a", "b", "c"]);
-                    t.pass();
-                    collected = collector.read();
-                }
+            .on("data", (collected) => {
+                expect(collected).to.deep.equal(["a", "b", "c"]);
+                t.pass();
             })
-            .on("error", t.end)
-            .on("end", t.end);
-
+            .on("error", reject)
+            .on("end", resolve);
         source.push("a");
         source.push("b");
         source.push("c");
         source.push(null);
-    },
-);
+    });
+});
 
-test.cb(
-    "collect() collects streamed bytes into a buffer (non-object, flowing mode)",
-    t => {
-        t.plan(1);
-        const source = new Readable({ objectMode: false });
+test("collect() collects streamed bytes into a buffer (non-object, flowing mode)", (t) => {
+    t.plan(1);
+    const source = new Readable({ objectMode: false, read: () => {} });
 
+    return new Promise((resolve, reject) => {
         source
             .pipe(collect({ objectMode: false }))
-            .on("data", collected => {
+            .on("data", (collected) => {
                 expect(collected).to.deep.equal(Buffer.from("abc"));
                 t.pass();
             })
-            .on("error", t.end)
-            .on("end", t.end);
+            .on("error", reject)
+            .on("end", resolve);
 
         source.push("a");
         source.push("b");
         source.push("c");
         source.push(null);
-    },
-);
+    });
+});
 
-test.cb(
-    "collect() collects streamed bytes into a buffer (non-object, paused mode)",
-    t => {
-        t.plan(1);
-        const source = new Readable({ objectMode: false });
-        const collector = source.pipe(collect({ objectMode: false }));
+test("collect() collects streamed bytes into a buffer (non-object, paused mode)", (t) => {
+    t.plan(1);
+    const source = new Readable({ objectMode: false, read: () => {} });
+    const collector = source.pipe(collect({ objectMode: false }));
+    return new Promise((resolve, reject) => {
         collector
-            .on("readable", () => {
-                let collected = collector.read();
-                while (collected !== null) {
-                    expect(collected).to.deep.equal(Buffer.from("abc"));
-                    t.pass();
-                    collected = collector.read();
-                }
+            .on("data", (collected) => {
+                expect(collected).to.deep.equal(Buffer.from("abc"));
+                t.pass();
             })
-            .on("error", t.end)
-            .on("end", t.end);
+            .on("error", reject)
+            .on("end", resolve);
 
         source.push("a");
         source.push("b");
         source.push("c");
         source.push(null);
-    },
-);
+    });
+});
 
-test.cb(
-    "collect() emits an empty array if the source was empty (object mode)",
-    t => {
-        t.plan(1);
-        const source = new Readable({ objectMode: true });
-        const collector = source.pipe(collect({ objectMode: true }));
+test("collect() emits an empty array if the source was empty (object mode)", (t) => {
+    t.plan(1);
+    const source = new Readable({ objectMode: true, read: function () {} });
+    const collector = source.pipe(collect({ objectMode: true }));
+    return new Promise((resolve, reject) => {
         collector
-            .on("data", collected => {
+            .on("data", (collected) => {
                 expect(collected).to.deep.equal([]);
                 t.pass();
             })
-            .on("error", t.end)
-            .on("end", t.end);
+            .on("error", reject)
+            .on("end", resolve);
 
         source.push(null);
-    },
-);
+    });
+});
 
-test.cb(
-    "collect() emits nothing if the source was empty (non-object mode)",
-    t => {
-        t.plan(0);
-        const source = new Readable({ objectMode: false });
-        const collector = source.pipe(collect({ objectMode: false }));
+test("collect() emits nothing if the source was empty (non-object mode)", (t) => {
+    t.plan(0);
+    const source = new Readable({ objectMode: false, read: function () {} });
+    const collector = source.pipe(collect({ objectMode: false }));
+    return new Promise((resolve, reject) => {
         collector
             .on("data", () => t.fail())
-            .on("error", t.end)
-            .on("end", t.end);
+            .on("error", reject)
+            .on("end", resolve);
 
         source.push(null);
-    },
-);
+    });
+});

--- a/tests/concat.spec.ts
+++ b/tests/concat.spec.ts
@@ -3,22 +3,21 @@ import test from "ava";
 import { expect } from "chai";
 import { concat, collect } from "../src";
 
-test.cb(
-    "concat() concatenates multiple readable streams (object, flowing mode)",
-    t => {
-        t.plan(6);
-        const source1 = new Readable({ objectMode: true });
-        const source2 = new Readable({ objectMode: true });
-        const expectedElements = ["a", "b", "c", "d", "e", "f"];
-        let i = 0;
+test("concat() concatenates multiple readable streams (object, flowing mode)", (t) => {
+    t.plan(6);
+    const source1 = new Readable({ objectMode: true });
+    const source2 = new Readable({ objectMode: true });
+    const expectedElements = ["a", "b", "c", "d", "e", "f"];
+    let i = 0;
+    return new Promise((resolve, reject) => {
         concat(source1, source2)
             .on("data", (element: string) => {
                 expect(element).to.equal(expectedElements[i]);
                 t.pass();
                 i++;
             })
-            .on("error", t.end)
-            .on("end", t.end);
+            .on("error", reject)
+            .on("end", resolve);
 
         source1.push("a");
         source2.push("d");
@@ -28,17 +27,17 @@ test.cb(
         source2.push("f");
         source2.push(null);
         source1.push(null);
-    },
-);
+    });
+});
 
-test.cb(
-    "concat() concatenates multiple readable streams (object, paused mode)",
-    t => {
-        t.plan(6);
-        const source1 = new Readable({ objectMode: true });
-        const source2 = new Readable({ objectMode: true });
-        const expectedElements = ["a", "b", "c", "d", "e", "f"];
-        let i = 0;
+test("concat() concatenates multiple readable streams (object, paused mode)", (t) => {
+    t.plan(6);
+    const source1 = new Readable({ objectMode: true });
+    const source2 = new Readable({ objectMode: true });
+    const expectedElements = ["a", "b", "c", "d", "e", "f"];
+    let i = 0;
+
+    return new Promise((resolve, reject) => {
         const concatenation = concat(source1, source2)
             .on("readable", () => {
                 let element = concatenation.read();
@@ -49,8 +48,8 @@ test.cb(
                     element = concatenation.read();
                 }
             })
-            .on("error", t.end)
-            .on("end", t.end);
+            .on("error", reject)
+            .on("end", resolve);
 
         source1.push("a");
         source2.push("d");
@@ -60,25 +59,24 @@ test.cb(
         source2.push("f");
         source2.push(null);
         source1.push(null);
-    },
-);
+    });
+});
 
-test.cb(
-    "concat() concatenates multiple readable streams (non-object, flowing mode)",
-    t => {
-        t.plan(6);
-        const source1 = new Readable({ objectMode: false });
-        const source2 = new Readable({ objectMode: false });
-        const expectedElements = ["a", "b", "c", "d", "e", "f"];
-        let i = 0;
+test("concat() concatenates multiple readable streams (non-object, flowing mode)", (t) => {
+    t.plan(6);
+    const source1 = new Readable({ objectMode: false });
+    const source2 = new Readable({ objectMode: false });
+    const expectedElements = ["a", "b", "c", "d", "e", "f"];
+    let i = 0;
+    return new Promise((resolve, reject) => {
         concat(source1, source2)
             .on("data", (element: string) => {
                 expect(element).to.deep.equal(Buffer.from(expectedElements[i]));
                 t.pass();
                 i++;
             })
-            .on("error", t.end)
-            .on("end", t.end);
+            .on("error", reject)
+            .on("end", resolve);
 
         source1.push("a");
         source2.push("d");
@@ -88,17 +86,16 @@ test.cb(
         source2.push("f");
         source2.push(null);
         source1.push(null);
-    },
-);
+    });
+});
 
-test.cb(
-    "concat() concatenates multiple readable streams (non-object, paused mode)",
-    t => {
-        t.plan(6);
-        const source1 = new Readable({ objectMode: false, read: () => ({}) });
-        const source2 = new Readable({ objectMode: false, read: () => ({}) });
-        const expectedElements = ["a", "b", "c", "d", "e", "f"];
-        let i = 0;
+test("concat() concatenates multiple readable streams (non-object, paused mode)", (t) => {
+    t.plan(6);
+    const source1 = new Readable({ objectMode: false, read: () => ({}) });
+    const source2 = new Readable({ objectMode: false, read: () => ({}) });
+    const expectedElements = ["a", "b", "c", "d", "e", "f"];
+    let i = 0;
+    return new Promise((resolve, reject) => {
         const concatenation = concat(source1, source2)
             .on("readable", () => {
                 let element = concatenation.read();
@@ -111,8 +108,8 @@ test.cb(
                     element = concatenation.read();
                 }
             })
-            .on("error", t.end)
-            .on("end", t.end);
+            .on("error", reject)
+            .on("end", resolve);
 
         source1.push("a");
         setTimeout(() => source2.push("d"), 10);
@@ -122,59 +119,62 @@ test.cb(
         setTimeout(() => source2.push("f"), 50);
         setTimeout(() => source2.push(null), 60);
         setTimeout(() => source1.push(null), 70);
-    },
-);
+    });
+});
 
-test.cb("concat() concatenates a single readable stream (object mode)", t => {
+test("concat() concatenates a single readable stream (object mode)", (t) => {
     t.plan(3);
     const source = new Readable({ objectMode: true });
     const expectedElements = ["a", "b", "c", "d", "e", "f"];
     let i = 0;
-    concat(source)
-        .on("data", (element: string) => {
-            expect(element).to.equal(expectedElements[i]);
-            t.pass();
-            i++;
-        })
-        .on("error", t.end)
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        concat(source)
+            .on("data", (element: string) => {
+                expect(element).to.equal(expectedElements[i]);
+                t.pass();
+                i++;
+            })
+            .on("error", reject)
+            .on("end", resolve);
 
-    source.push("a");
-    source.push("b");
-    source.push("c");
-    source.push(null);
+        source.push("a");
+        source.push("b");
+        source.push("c");
+        source.push(null);
+    });
 });
 
-test.cb(
-    "concat() concatenates a single readable stream (non-object mode)",
-    t => {
-        t.plan(3);
-        const source = new Readable({ objectMode: false });
-        const expectedElements = ["a", "b", "c", "d", "e", "f"];
-        let i = 0;
+test("concat() concatenates a single readable stream (non-object mode)", (t) => {
+    t.plan(3);
+    const source = new Readable({ objectMode: false });
+    const expectedElements = ["a", "b", "c", "d", "e", "f"];
+    let i = 0;
+    return new Promise((resolve, reject) => {
         concat(source)
             .on("data", (element: string) => {
                 expect(element).to.deep.equal(Buffer.from(expectedElements[i]));
                 t.pass();
                 i++;
             })
-            .on("error", t.end)
-            .on("end", t.end);
+            .on("error", reject)
+            .on("end", resolve);
 
         source.push("a");
         source.push("b");
         source.push("c");
         source.push(null);
-    },
-);
+    });
+});
 
-test.cb("concat() concatenates empty list of readable streams", t => {
+test("concat() concatenates empty list of readable streams", (t) => {
     t.plan(0);
-    concat()
-        .pipe(collect({ objectMode: false }))
-        .on("data", _ => {
-            t.fail();
-        })
-        .on("error", t.end)
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        concat()
+            .pipe(collect({ objectMode: false }))
+            .on("data", (_) => {
+                t.fail();
+            })
+            .on("error", reject)
+            .on("end", resolve);
+    });
 });

--- a/tests/demux.spec.ts
+++ b/tests/demux.spec.ts
@@ -11,7 +11,7 @@ interface Test {
     visited: number[];
 }
 
-test.cb("demux() constructor should be called once per key", t => {
+test("demux() constructor should be called once per key", (t) => {
     t.plan(1);
     const input = [
         { key: "a", visited: [] },
@@ -30,18 +30,20 @@ test.cb("demux() constructor should be called once per key", t => {
 
     const demuxed = demux(construct, "key", {});
 
-    demuxed.on("finish", () => {
-        expect(construct.withArgs("a").callCount).to.equal(1);
-        expect(construct.withArgs("b").callCount).to.equal(1);
-        expect(construct.withArgs("c").callCount).to.equal(1);
-        t.pass();
-        t.end();
-    });
+    return new Promise((resolve, reject) => {
+        demuxed.on("finish", () => {
+            expect(construct.withArgs("a").callCount).to.equal(1);
+            expect(construct.withArgs("b").callCount).to.equal(1);
+            expect(construct.withArgs("c").callCount).to.equal(1);
+            t.pass();
+            resolve();
+        });
 
-    fromArray(input).pipe(demuxed);
+        fromArray(input).pipe(demuxed);
+    });
 });
 
-test.cb("demux() item written passed in constructor", t => {
+test("demux() item written passed in constructor", (t) => {
     t.plan(4);
     const input = [
         { key: "a", visited: [] },
@@ -61,15 +63,17 @@ test.cb("demux() item written passed in constructor", t => {
 
     const demuxed = demux(construct, "key", {});
 
-    demuxed.on("finish", () => {
-        t.pass();
-        t.end();
-    });
+    return new Promise((resolve, reject) => {
+        demuxed.on("finish", () => {
+            t.pass();
+            resolve();
+        });
 
-    fromArray(input).pipe(demuxed);
+        fromArray(input).pipe(demuxed);
+    });
 });
 
-test.cb("demux() should send input through correct pipeline", t => {
+test("demux() should send input through correct pipeline", (t) => {
     t.plan(6);
     const input = [
         { key: "a", visited: [] },
@@ -79,7 +83,7 @@ test.cb("demux() should send input through correct pipeline", t => {
         { key: "a", visited: [] },
         { key: "b", visited: [] },
     ];
-    const pipelineSpies = {};
+    const pipelineSpies: any = {};
     const construct = (destKey: string) => {
         const mapper = sinon.spy((chunk: Test) => {
             return { ...chunk, visited: [1] };
@@ -92,26 +96,28 @@ test.cb("demux() should send input through correct pipeline", t => {
 
     const demuxed = demux(construct, "key", {});
 
-    demuxed.on("finish", () => {
-        pipelineSpies["a"].getCalls().forEach(call => {
-            expect(call.args[0].key).to.equal("a");
-            t.pass();
+    return new Promise((resolve, reject) => {
+        demuxed.on("finish", () => {
+            pipelineSpies.a.getCalls().forEach((call) => {
+                expect(call.args[0].key).to.equal("a");
+                t.pass();
+            });
+            pipelineSpies.b.getCalls().forEach((call) => {
+                expect(call.args[0].key).to.equal("b");
+                t.pass();
+            });
+            pipelineSpies.c.getCalls().forEach((call) => {
+                expect(call.args[0].key).to.equal("c");
+                t.pass();
+            });
+            resolve();
         });
-        pipelineSpies["b"].getCalls().forEach(call => {
-            expect(call.args[0].key).to.equal("b");
-            t.pass();
-        });
-        pipelineSpies["c"].getCalls().forEach(call => {
-            expect(call.args[0].key).to.equal("c");
-            t.pass();
-        });
-        t.end();
-    });
 
-    fromArray(input).pipe(demuxed);
+        fromArray(input).pipe(demuxed);
+    });
 });
 
-test.cb("demux() constructor should be called once per key using keyBy", t => {
+test("demux() constructor should be called once per key using keyBy", (t) => {
     t.plan(1);
     const input = [
         { key: "a", visited: [] },
@@ -129,20 +135,22 @@ test.cb("demux() constructor should be called once per key using keyBy", t => {
         });
     });
 
-    const demuxed = demux(construct, item => item.key, {});
+    const demuxed = demux(construct, (item) => item.key, {});
 
-    demuxed.on("finish", () => {
-        expect(construct.withArgs("a").callCount).to.equal(1);
-        expect(construct.withArgs("b").callCount).to.equal(1);
-        expect(construct.withArgs("c").callCount).to.equal(1);
-        t.pass();
-        t.end();
+    return new Promise((resolve, reject) => {
+        demuxed.on("finish", () => {
+            expect(construct.withArgs("a").callCount).to.equal(1);
+            expect(construct.withArgs("b").callCount).to.equal(1);
+            expect(construct.withArgs("c").callCount).to.equal(1);
+            t.pass();
+            resolve();
+        });
+
+        fromArray(input).pipe(demuxed);
     });
-
-    fromArray(input).pipe(demuxed);
 });
 
-test.cb("demux() should send input through correct pipeline using keyBy", t => {
+test("demux() should send input through correct pipeline using keyBy", (t) => {
     t.plan(6);
     const input = [
         { key: "a", visited: [] },
@@ -152,7 +160,7 @@ test.cb("demux() should send input through correct pipeline using keyBy", t => {
         { key: "a", visited: [] },
         { key: "b", visited: [] },
     ];
-    const pipelineSpies = {};
+    const pipelineSpies: any = {};
     const construct = (destKey: string) => {
         const mapper = sinon.spy((chunk: Test) => {
             return { ...chunk, visited: [1] };
@@ -163,41 +171,43 @@ test.cb("demux() should send input through correct pipeline using keyBy", t => {
         return dest;
     };
 
-    const demuxed = demux(construct, item => item.key, {});
+    const demuxed = demux(construct, (item) => item.key, {});
 
-    demuxed.on("finish", () => {
-        pipelineSpies["a"].getCalls().forEach(call => {
-            expect(call.args[0].key).to.equal("a");
-            t.pass();
+    return new Promise((resolve, reject) => {
+        demuxed.on("finish", () => {
+            pipelineSpies.a.getCalls().forEach((call) => {
+                expect(call.args[0].key).to.equal("a");
+                t.pass();
+            });
+            pipelineSpies.b.getCalls().forEach((call) => {
+                expect(call.args[0].key).to.equal("b");
+                t.pass();
+            });
+            pipelineSpies.c.getCalls().forEach((call) => {
+                expect(call.args[0].key).to.equal("c");
+                t.pass();
+            });
+            resolve();
         });
-        pipelineSpies["b"].getCalls().forEach(call => {
-            expect(call.args[0].key).to.equal("b");
-            t.pass();
-        });
-        pipelineSpies["c"].getCalls().forEach(call => {
-            expect(call.args[0].key).to.equal("c");
-            t.pass();
-        });
-        t.end();
+
+        fromArray(input).pipe(demuxed);
     });
-
-    fromArray(input).pipe(demuxed);
 });
 
-test("demux() write should return false and emit drain if more than highWaterMark items are buffered", t => {
+test("demux() write should return false and emit drain if more than highWaterMark items are buffered", (t) => {
     return new Promise(async (resolve, reject) => {
         t.plan(7);
         interface Chunk {
             key: string;
-            mapped: number[];
+            mapped: boolean;
         }
         const input: Chunk[] = [
-            { key: "a", mapped: [] },
-            { key: "a", mapped: [] },
-            { key: "a", mapped: [] },
-            { key: "a", mapped: [] },
-            { key: "a", mapped: [] },
-            { key: "a", mapped: [] },
+            { key: "a", mapped: false },
+            { key: "b", mapped: false },
+            { key: "c", mapped: false },
+            { key: "d", mapped: false },
+            { key: "e", mapped: false },
+            { key: "f", mapped: false },
         ];
         let pendingReads = input.length;
         const highWaterMark = 5;
@@ -206,18 +216,18 @@ test("demux() write should return false and emit drain if more than highWaterMar
             const first = map(
                 async (chunk: Chunk) => {
                     await sleep(slowProcessorSpeed);
-                    return { ...chunk, mapped: [1] };
+                    return { ...chunk, mapped: true };
                 },
                 { highWaterMark: 1 },
             );
 
-            first.on("data", chunk => {
-                expect(chunk.mapped).to.deep.equal([1]);
+            first.on("data", (chunk) => {
+                expect(chunk.mapped).to.be.true;
                 pendingReads--;
+                t.pass();
                 if (pendingReads === 0) {
                     resolve();
                 }
-                t.pass();
             });
 
             return first;
@@ -227,19 +237,24 @@ test("demux() write should return false and emit drain if more than highWaterMar
             highWaterMark,
         });
 
-        _demux.on("error", _err => {
+        _demux.on("error", (_err) => {
             reject();
         });
 
         for (const item of input) {
             const res = _demux.write(item);
-            expect(_demux._writableState.length).to.be.at.most(highWaterMark);
+            expect((_demux as any)._writableState.length).to.be.at.most(
+                highWaterMark,
+            );
             if (!res) {
-                await new Promise((resolv, _rej) => {
+                await new Promise((_resolve, _rej) => {
                     _demux.once("drain", () => {
-                        expect(_demux._writableState.length).to.be.equal(0);
+                        expect(
+                            (_demux as any)._writableState.length,
+                        ).to.be.equal(0);
                         t.pass();
-                        resolv();
+                        //Nested resolve
+                        _resolve(undefined);
                     });
                 });
             }
@@ -247,7 +262,7 @@ test("demux() write should return false and emit drain if more than highWaterMar
     });
 });
 
-test("demux() should emit one drain event after slowProcessorSpeed * highWaterMark ms when first stream is bottleneck", t => {
+test("demux() should emit one drain event after slowProcessorSpeed * highWaterMark ms when first stream is bottleneck", (t) => {
     return new Promise(async (resolve, reject) => {
         t.plan(7);
         interface Chunk {
@@ -288,7 +303,7 @@ test("demux() should emit one drain event after slowProcessorSpeed * highWaterMa
         const _demux = demux(construct, "key", {
             highWaterMark,
         });
-        _demux.on("error", _err => {
+        _demux.on("error", (_err) => {
             reject();
         });
 
@@ -311,7 +326,7 @@ test("demux() should emit one drain event after slowProcessorSpeed * highWaterMa
     });
 });
 
-test("demux() should emit one drain event when writing 6 items with highWaterMark of 5", t => {
+test("demux() should emit one drain event when writing 6 items with highWaterMark of 5", (t) => {
     return new Promise(async (resolve, reject) => {
         t.plan(1);
         interface Chunk {
@@ -350,18 +365,22 @@ test("demux() should emit one drain event when writing 6 items with highWaterMar
             highWaterMark: 5,
         });
 
-        _demux.on("error", _err => {
+        _demux.on("error", (_err) => {
             reject();
         });
 
         for (const item of input) {
             const res = _demux.write(item);
-            expect(_demux._writableState.length).to.be.at.most(highWaterMark);
+            expect((_demux as any)._writableState.length).to.be.at.most(
+                highWaterMark,
+            );
             if (!res) {
-                await new Promise(_resolve => {
+                await new Promise((_resolve) => {
                     _demux.once("drain", () => {
                         _resolve(null);
-                        expect(_demux._writableState.length).to.be.equal(0);
+                        expect(
+                            (_demux as any)._writableState.length,
+                        ).to.be.equal(0);
                         t.pass();
                     });
                 });
@@ -370,17 +389,16 @@ test("demux() should emit one drain event when writing 6 items with highWaterMar
     });
 });
 
-test.cb(
-    "demux() should emit drain event when second stream is bottleneck after (highWaterMark - 2) * slowProcessorSpeed ms",
-    t => {
-        // ie) first two items are pushed directly into first and second streams (highWaterMark - 2 remain in demux)
-        t.plan(8);
-        const slowProcessorSpeed = 100;
-        const highWaterMark = 5;
-        interface Chunk {
-            key: string;
-            mapped: number[];
-        }
+test("demux() should emit drain event when second stream is bottleneck after (highWaterMark - 2) * slowProcessorSpeed ms", (t) => {
+    // ie) first two items are pushed directly into first and second streams (highWaterMark - 2 remain in demux)
+    t.plan(8);
+    const slowProcessorSpeed = 100;
+    const highWaterMark = 5;
+    interface Chunk {
+        key: string;
+        mapped: number[];
+    }
+    return new Promise((resolve, reject) => {
         const sink = new Writable({
             objectMode: true,
             write(chunk, encoding, cb) {
@@ -388,8 +406,9 @@ test.cb(
                 t.pass();
                 pendingReads--;
                 if (pendingReads === 0) {
-                    t.end();
+                    resolve();
                 }
+
                 cb();
             },
         });
@@ -417,12 +436,12 @@ test.cb(
         const _demux = demux(construct, () => "a", {
             highWaterMark,
         });
-        _demux.on("error", err => {
-            t.end(err);
+        _demux.on("error", (err) => {
+            reject(err);
         });
 
         _demux.on("drain", () => {
-            expect(_demux._writableState.length).to.be.equal(0);
+            expect((_demux as any)._writableState.length).to.be.equal(0);
             expect(performance.now() - start).to.be.greaterThan(
                 slowProcessorSpeed * 3,
             );
@@ -442,20 +461,19 @@ test.cb(
 
         const start = performance.now();
         fromArray(input).pipe(_demux);
-    },
-);
+    });
+});
 
-test.cb(
-    "demux() should emit drain event when third stream is bottleneck",
-    t => {
-        // @TODO investigate why drain is emitted after slowProcessorSpeed
-        t.plan(8);
-        const slowProcessorSpeed = 100;
-        const highWaterMark = 5;
-        interface Chunk {
-            key: string;
-            mapped: number[];
-        }
+test("demux() should emit drain event when third stream is bottleneck", (t) => {
+    // @TODO investigate why drain is emitted after slowProcessorSpeed
+    t.plan(8);
+    const slowProcessorSpeed = 100;
+    const highWaterMark = 5;
+    interface Chunk {
+        key: string;
+        mapped: number[];
+    }
+    return new Promise((resolve, reject) => {
         const sink = new Writable({
             objectMode: true,
             write(chunk, encoding, cb) {
@@ -463,7 +481,7 @@ test.cb(
                 t.pass();
                 pendingReads--;
                 if (pendingReads === 0) {
-                    t.end();
+                    resolve();
                 }
                 cb();
             },
@@ -493,21 +511,18 @@ test.cb(
                 { highWaterMark: 1 },
             );
 
-            first
-                .pipe(second)
-                .pipe(third)
-                .pipe(sink);
+            first.pipe(second).pipe(third).pipe(sink);
             return first;
         };
         const _demux = demux(construct, () => "a", {
             highWaterMark,
         });
-        _demux.on("error", err => {
-            t.end(err);
+        _demux.on("error", (err) => {
+            reject(err);
         });
 
         _demux.on("drain", () => {
-            expect(_demux._writableState.length).to.be.equal(0);
+            expect((_demux as any)._writableState.length).to.be.equal(0);
             expect(performance.now() - start).to.be.greaterThan(
                 slowProcessorSpeed,
             );
@@ -527,10 +542,10 @@ test.cb(
 
         const start = performance.now();
         fromArray(input).pipe(_demux);
-    },
-);
+    });
+});
 
-test("demux() should be blocked by slowest pipeline", t => {
+test("demux() should be blocked by slowest pipeline", (t) => {
     t.plan(1);
     const slowProcessorSpeed = 100;
     interface Chunk {
@@ -555,11 +570,11 @@ test("demux() should be blocked by slowest pipeline", t => {
             highWaterMark: 1,
         });
 
-        _demux.on("error", err => {
+        _demux.on("error", (err) => {
             reject(err);
         });
 
-        _demux.on("data", async chunk => {
+        _demux.on("data", async (chunk) => {
             pendingReads--;
             if (chunk.key === "b") {
                 expect(performance.now() - start).to.be.greaterThan(
@@ -584,9 +599,9 @@ test("demux() should be blocked by slowest pipeline", t => {
         const start = performance.now();
         for (const item of input) {
             if (!_demux.write(item)) {
-                await new Promise(_resolve => {
+                await new Promise((_resolve) => {
                     _demux.once("drain", () => {
-                        _resolve();
+                        _resolve(undefined);
                     });
                 });
             }
@@ -594,7 +609,7 @@ test("demux() should be blocked by slowest pipeline", t => {
     });
 });
 
-test.cb("Demux should remux to sink", t => {
+test("Demux should remux to sink", (t) => {
     t.plan(6);
     let i = 0;
     const input = [
@@ -622,22 +637,23 @@ test.cb("Demux should remux to sink", t => {
         return dest;
     };
 
-    const sink = map(d => {
-        t.deepEqual(d, result[i]);
-        i++;
-        if (i === input.length) {
-            t.end();
-        }
+    return new Promise((resolve, reject) => {
+        const sink = map((d) => {
+            t.deepEqual(d, result[i]);
+            i++;
+            if (i === input.length) {
+                resolve();
+            }
+        });
+
+        const demuxed = demux(construct, "key", {});
+
+        fromArray(input).pipe(demuxed).pipe(sink);
+        demuxed.on("error", reject);
     });
-
-    const demuxed = demux(construct, "key", {});
-
-    fromArray(input)
-        .pipe(demuxed)
-        .pipe(sink);
 });
 
-test.cb("Demux should send data events", t => {
+test("Demux should send data events", (t) => {
     t.plan(6);
     let i = 0;
     const input = [
@@ -669,16 +685,18 @@ test.cb("Demux should send data events", t => {
 
     fromArray(input).pipe(demuxed);
 
-    demuxed.on("data", d => {
-        t.deepEqual(d, result[i]);
-        i++;
-        if (i === input.length) {
-            t.end();
-        }
+    return new Promise((resolve, reject) => {
+        demuxed.on("data", (d) => {
+            t.deepEqual(d, result[i]);
+            i++;
+            if (i === input.length) {
+                resolve();
+            }
+        });
     });
 });
 
-test.cb("demux() `finish` and `end` propagates", t => {
+test("demux() `finish` and `end` propagates", (t) => {
     t.plan(10);
     const construct = (destKey: string) => {
         const dest = map((chunk: any) => {
@@ -698,6 +716,13 @@ test.cb("demux() `finish` and `end` propagates", t => {
             return;
         },
     });
+    const input = [
+        { key: "a", mapped: [] },
+        { key: "b", mapped: [] },
+        { key: "a", mapped: [] },
+        { key: "a", mapped: [] },
+        { key: "b", mapped: [] },
+    ];
 
     const sink = map((d: any) => {
         const curr = input.shift();
@@ -719,24 +744,19 @@ test.cb("demux() `finish` and `end` propagates", t => {
     _demux.on("end", () => {
         t.pass();
     });
-    sink.on("finish", () => {
-        t.pass();
-        t.end();
-    });
+    return new Promise((resolve, reject) => {
+        sink.on("finish", () => {
+            t.pass();
+            resolve();
+        });
 
-    const input = [
-        { key: "a", mapped: [] },
-        { key: "b", mapped: [] },
-        { key: "a", mapped: [] },
-        { key: "a", mapped: [] },
-        { key: "b", mapped: [] },
-    ];
-    fakeSource.push(input[0]);
-    fakeSource.push(input[1]);
-    fakeSource.push(null);
+        fakeSource.push(input[0]);
+        fakeSource.push(input[1]);
+        fakeSource.push(null);
+    });
 });
 
-test.cb("demux() `unpipe` propagates", t => {
+test("demux() `unpipe` propagates", (t) => {
     interface Chunk {
         key: string;
         mapped: number[];
@@ -763,6 +783,14 @@ test.cb("demux() `unpipe` propagates", t => {
         },
     });
 
+    const input = [
+        { key: "a", mapped: [] },
+        { key: "b", mapped: [] },
+        { key: "a", mapped: [] },
+        { key: "a", mapped: [] },
+        { key: "b", mapped: [] },
+    ];
+
     const sink = map((d: any) => {
         const curr = input.shift();
         t.is(curr.key, d.key);
@@ -779,24 +807,19 @@ test.cb("demux() `unpipe` propagates", t => {
         t.pass();
     });
 
-    sink.on("finish", () => {
-        t.pass();
-        t.end();
-    });
+    return new Promise((resolve) => {
+        sink.on("finish", () => {
+            t.pass();
+            resolve();
+        });
 
-    const input = [
-        { key: "a", mapped: [] },
-        { key: "b", mapped: [] },
-        { key: "a", mapped: [] },
-        { key: "a", mapped: [] },
-        { key: "b", mapped: [] },
-    ];
-    fakeSource.push(input[0]);
-    fakeSource.push(input[1]);
-    fakeSource.push(null);
+        fakeSource.push(input[0]);
+        fakeSource.push(input[1]);
+        fakeSource.push(null);
+    });
 });
 
-test.cb("demux() should be 'destroyable'", t => {
+test("demux() should be 'destroyable'", (t) => {
     t.plan(2);
     const _sleep = 100;
     interface Chunk {
@@ -822,6 +845,13 @@ test.cb("demux() should be 'destroyable'", t => {
         },
     });
 
+    const input = [
+        { key: "a", mapped: [] },
+        { key: "b", mapped: [] },
+        { key: "c", mapped: [] },
+        { key: "d", mapped: [] },
+        { key: "e", mapped: [] },
+    ];
     const fakeSink = new Writable({
         objectMode: true,
         write(data, enc, cb) {
@@ -835,19 +865,14 @@ test.cb("demux() should be 'destroyable'", t => {
         },
     });
 
-    _demux.on("close", t.end);
-    fakeSource.pipe(_demux).pipe(fakeSink);
+    return new Promise((resolve) => {
+        _demux.on("close", resolve);
+        fakeSource.pipe(_demux).pipe(fakeSink);
 
-    const input = [
-        { key: "a", mapped: [] },
-        { key: "b", mapped: [] },
-        { key: "c", mapped: [] },
-        { key: "d", mapped: [] },
-        { key: "e", mapped: [] },
-    ];
-    fakeSource.push(input[0]);
-    fakeSource.push(input[1]);
-    fakeSource.push(input[2]);
-    fakeSource.push(input[3]);
-    fakeSource.push(input[4]);
+        fakeSource.push(input[0]);
+        fakeSource.push(input[1]);
+        fakeSource.push(input[2]);
+        fakeSource.push(input[3]);
+        fakeSource.push(input[4]);
+    });
 });

--- a/tests/duplex.spec.ts
+++ b/tests/duplex.spec.ts
@@ -4,25 +4,24 @@ import test from "ava";
 import { expect } from "chai";
 import { duplex } from "../src";
 
-test.cb(
-    "duplex() combines a writable and readable stream into a ReadWrite stream",
-    t => {
-        t.plan(1);
-        const source = new Readable();
-        const catProcess = cp.exec("cat");
-        let out = "";
+test("duplex() combines a writable and readable stream into a ReadWrite stream", (t) => {
+    t.plan(1);
+    const source = new Readable();
+    const catProcess = cp.exec("cat");
+    let out = "";
+    return new Promise((resolve, reject) => {
         source
             .pipe(duplex(catProcess.stdin!, catProcess.stdout!))
-            .on("data", chunk => (out += chunk))
-            .on("error", t.end)
+            .on("data", (chunk) => (out += chunk))
+            .on("error", reject)
             .on("end", () => {
                 expect(out).to.equal("abcdef");
                 t.pass();
-                t.end();
+                resolve();
             });
         source.push("ab");
         source.push("cd");
         source.push("ef");
         source.push(null);
-    },
-);
+    });
+});

--- a/tests/filter.spec.ts
+++ b/tests/filter.spec.ts
@@ -3,114 +3,120 @@ import { expect } from "chai";
 import { Readable } from "stream";
 import { filter } from "../src";
 
-test.cb("filter() filters elements synchronously", t => {
+test("filter() filters elements synchronously", (t) => {
     t.plan(2);
     const source = new Readable({ objectMode: true });
     const expectedElements = ["a", "c"];
     let i = 0;
-    source
-        .pipe(
-            filter((element: string) => element !== "b", {
-                readableObjectMode: true,
-                writableObjectMode: true,
-            }),
-        )
-        .on("data", (element: string) => {
-            expect(element).to.equal(expectedElements[i]);
-            t.pass();
-            i++;
-        })
-        .on("error", t.end)
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(
+                filter((element: string) => element !== "b", {
+                    readableObjectMode: true,
+                    writableObjectMode: true,
+                }),
+            )
+            .on("data", (element: string) => {
+                expect(element).to.equal(expectedElements[i]);
+                t.pass();
+                i++;
+            })
+            .on("error", reject)
+            .on("end", resolve);
 
-    source.push("a");
-    source.push("b");
-    source.push("c");
-    source.push(null);
+        source.push("a");
+        source.push("b");
+        source.push("c");
+        source.push(null);
+    });
 });
 
-test.cb("filter() filters elements asynchronously", t => {
+test("filter() filters elements asynchronously", (t) => {
     t.plan(2);
     const source = new Readable({ objectMode: true });
     const expectedElements = ["a", "c"];
     let i = 0;
-    source
-        .pipe(
-            filter(
-                async (element: string) => {
-                    await Promise.resolve();
-                    return element !== "b";
-                },
-                { readableObjectMode: true, writableObjectMode: true },
-            ),
-        )
-        .on("data", (element: string) => {
-            expect(element).to.equal(expectedElements[i]);
-            t.pass();
-            i++;
-        })
-        .on("error", t.end)
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(
+                filter(
+                    async (element: string) => {
+                        await Promise.resolve();
+                        return element !== "b";
+                    },
+                    { readableObjectMode: true, writableObjectMode: true },
+                ),
+            )
+            .on("data", (element: string) => {
+                expect(element).to.equal(expectedElements[i]);
+                t.pass();
+                i++;
+            })
+            .on("error", reject)
+            .on("end", resolve);
 
-    source.push("a");
-    source.push("b");
-    source.push("c");
-    source.push(null);
+        source.push("a");
+        source.push("b");
+        source.push("c");
+        source.push(null);
+    });
 });
 
-test.cb.skip("filter() emits errors during synchronous filtering", t => {
-    t.plan(2);
+test("filter() emits errors during synchronous filtering", (t) => {
+    t.plan(1);
     const source = new Readable({ objectMode: true });
-    source
-        .pipe(
-            filter(
-                (element: string) => {
-                    if (element !== "a") {
-                        throw new Error("Failed filtering");
-                    }
-                    return true;
-                },
-                { readableObjectMode: true, writableObjectMode: true },
-            ),
-        )
-        .resume()
-        .on("error", err => {
-            expect(err.message).to.equal("Failed filtering");
-            t.pass();
-        })
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(
+                filter(
+                    (element: string) => {
+                        if (element !== "a") {
+                            throw new Error("Failed filtering");
+                        }
+                        return true;
+                    },
+                    { readableObjectMode: true, writableObjectMode: true },
+                ),
+            )
+            .on("error", (err) => {
+                expect(err.message).to.equal("Failed filtering");
+                t.pass();
+            })
+            .on("close", resolve);
 
-    source.push("a");
-    source.push("b");
-    source.push("c");
-    source.push(null);
+        source.push("a");
+        source.push("b");
+        source.push("c");
+        source.push(null);
+    });
 });
 
-test.cb.skip("filter() emits errors during asynchronous filtering", t => {
-    t.plan(2);
+test("filter() emits errors during asynchronous filtering", (t) => {
+    t.plan(1);
     const source = new Readable({ objectMode: true });
-    source
-        .pipe(
-            filter(
-                async (element: string) => {
-                    await Promise.resolve();
-                    if (element !== "a") {
-                        throw new Error("Failed filtering");
-                    }
-                    return true;
-                },
-                { readableObjectMode: true, writableObjectMode: true },
-            ),
-        )
-        .resume()
-        .on("error", err => {
-            expect(err.message).to.equal("Failed filtering");
-            t.pass();
-        })
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(
+                filter(
+                    async (element: string) => {
+                        await Promise.resolve();
+                        if (element !== "a") {
+                            throw new Error("Failed filtering");
+                        }
+                        return true;
+                    },
+                    { readableObjectMode: true, writableObjectMode: true },
+                ),
+            )
+            .on("error", (err) => {
+                expect(err.message).to.equal("Failed filtering");
+                t.pass();
+            })
+            .on("close", resolve);
 
-    source.push("a");
-    source.push("b");
-    source.push("c");
-    source.push(null);
+        source.push("a");
+        source.push("b");
+        source.push("c");
+        source.push(null);
+    });
 });

--- a/tests/flatMap.spec.ts
+++ b/tests/flatMap.spec.ts
@@ -3,98 +3,108 @@ import test from "ava";
 import { expect } from "chai";
 import { flatMap } from "../src";
 
-test.cb("flatMap() maps elements synchronously", t => {
+test("flatMap() maps elements synchronously", (t) => {
     t.plan(6);
     const source = new Readable({ objectMode: true });
     const expectedElements = ["a", "A", "b", "B", "c", "C"];
     let i = 0;
-    source
-        .pipe(flatMap((element: string) => [element, element.toUpperCase()]))
-        .on("data", (element: string) => {
-            expect(element).to.equal(expectedElements[i]);
-            t.pass();
-            i++;
-        })
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(
+                flatMap((element: string) => [element, element.toUpperCase()]),
+            )
+            .on("data", (element: string) => {
+                expect(element).to.equal(expectedElements[i]);
+                t.pass();
+                i++;
+            })
+            .on("end", resolve);
 
-    source.push("a");
-    source.push("b");
-    source.push("c");
-    source.push(null);
+        source.push("a");
+        source.push("b");
+        source.push("c");
+        source.push(null);
+    });
 });
 
-test.cb("flatMap() maps elements asynchronously", t => {
+test("flatMap() maps elements asynchronously", (t) => {
     t.plan(6);
     const source = new Readable({ objectMode: true });
     const expectedElements = ["a", "A", "b", "B", "c", "C"];
     let i = 0;
-    source
-        .pipe(
-            flatMap(async (element: string) => {
-                await Promise.resolve();
-                return [element, element.toUpperCase()];
-            }),
-        )
-        .on("data", (element: string) => {
-            expect(element).to.equal(expectedElements[i]);
-            t.pass();
-            i++;
-        })
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(
+                flatMap(async (element: string) => {
+                    await Promise.resolve();
+                    return [element, element.toUpperCase()];
+                }),
+            )
+            .on("data", (element: string) => {
+                expect(element).to.equal(expectedElements[i]);
+                t.pass();
+                i++;
+            })
+            .on("end", resolve);
 
-    source.push("a");
-    source.push("b");
-    source.push("c");
-    source.push(null);
+        source.push("a");
+        source.push("b");
+        source.push("c");
+        source.push(null);
+    });
 });
 
-test.cb.skip("flatMap() emits errors during synchronous mapping", t => {
-    t.plan(2);
+test("flatMap() emits errors during synchronous mapping", (t) => {
+    t.plan(1);
     const source = new Readable({ objectMode: true });
-    source
-        .pipe(
-            flatMap((element: string) => {
-                if (element !== "a") {
-                    throw new Error("Failed mapping");
-                }
-                return [element, element.toUpperCase()];
-            }),
-        )
-        .resume()
-        .on("error", err => {
-            expect(err.message).to.equal("Failed mapping");
-            t.pass();
-        })
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(
+                flatMap((element: string) => {
+                    if (element !== "a") {
+                        throw new Error("Failed mapping");
+                    }
+                    return [element, element.toUpperCase()];
+                }),
+            )
+            .resume()
+            .on("error", (err) => {
+                expect(err.message).to.equal("Failed mapping");
+                t.pass();
+            })
+            .on("close", resolve);
 
-    source.push("a");
-    source.push("b");
-    source.push("c");
-    source.push(null);
+        source.push("a");
+        source.push("b");
+        source.push("c");
+        source.push(null);
+    });
 });
 
-test.cb.skip("flatMap() emits errors during asynchronous mapping", t => {
-    t.plan(2);
+test("flatMap() emits errors during asynchronous mapping", (t) => {
+    t.plan(1);
     const source = new Readable({ objectMode: true });
-    source
-        .pipe(
-            flatMap(async (element: string) => {
-                await Promise.resolve();
-                if (element !== "a") {
-                    throw new Error("Failed mapping");
-                }
-                return [element, element.toUpperCase()];
-            }),
-        )
-        .resume()
-        .on("error", err => {
-            expect(err.message).to.equal("Failed mapping");
-            t.pass();
-        })
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(
+                flatMap(async (element: string) => {
+                    await Promise.resolve();
+                    if (element !== "a") {
+                        throw new Error("Failed mapping");
+                    }
+                    return [element, element.toUpperCase()];
+                }),
+            )
+            .resume()
+            .on("error", (err) => {
+                expect(err.message).to.equal("Failed mapping");
+                t.pass();
+            })
+            .on("close", resolve);
 
-    source.push("a");
-    source.push("b");
-    source.push("c");
-    source.push(null);
+        source.push("a");
+        source.push("b");
+        source.push("c");
+        source.push(null);
+    });
 });

--- a/tests/fromArray.spec.ts
+++ b/tests/fromArray.spec.ts
@@ -2,44 +2,50 @@ import test from "ava";
 import { expect } from "chai";
 import { fromArray } from "../src";
 
-test.cb("fromArray() streams array elements in flowing mode", t => {
+test("fromArray() streams array elements in flowing mode", (t) => {
     t.plan(3);
     const elements = ["a", "b", "c"];
     const stream = fromArray(elements);
     let i = 0;
-    stream
-        .on("data", (element: string) => {
-            expect(element).to.equal(elements[i]);
-            t.pass();
-            i++;
-        })
-        .on("error", t.end)
-        .on("end", t.end);
-});
-
-test.cb("fromArray() ends immediately if there are no array elements", t => {
-    t.plan(0);
-    fromArray([])
-        .on("data", () => t.fail())
-        .on("error", t.end)
-        .on("end", t.end);
-});
-
-test.cb("fromArray() streams array elements in paused mode", t => {
-    t.plan(3);
-    const elements = ["a", "b", "c"];
-    const stream = fromArray(elements);
-    let i = 0;
-    stream
-        .on("readable", () => {
-            let element = stream.read();
-            while (element !== null) {
+    return new Promise((resolve, reject) => {
+        stream
+            .on("data", (element: string) => {
                 expect(element).to.equal(elements[i]);
                 t.pass();
                 i++;
-                element = stream.read();
-            }
-        })
-        .on("error", t.end)
-        .on("end", t.end);
+            })
+            .on("error", reject)
+            .on("end", resolve);
+    });
+});
+
+test("fromArray() ends immediately if there are no array elements", (t) => {
+    t.plan(0);
+    return new Promise((resolve, reject) => {
+        fromArray([])
+            .on("data", () => t.fail())
+            .on("error", reject)
+            .on("end", resolve);
+    });
+});
+
+test("fromArray() streams array elements in paused mode", (t) => {
+    t.plan(3);
+    const elements = ["a", "b", "c"];
+    const stream = fromArray(elements);
+    let i = 0;
+    return new Promise((resolve, reject) => {
+        stream
+            .on("readable", () => {
+                let element = stream.read();
+                while (element !== null) {
+                    expect(element).to.equal(elements[i]);
+                    t.pass();
+                    i++;
+                    element = stream.read();
+                }
+            })
+            .on("error", reject)
+            .on("end", resolve);
+    });
 });

--- a/tests/join.spec.ts
+++ b/tests/join.spec.ts
@@ -3,54 +3,58 @@ import test from "ava";
 import { expect } from "chai";
 import { join } from "../src";
 
-test.cb("join() joins chunks using the specified separator", t => {
+test("join() joins chunks using the specified separator", (t) => {
     t.plan(9);
     const source = new Readable({ objectMode: true });
     const expectedParts = ["ab|", "|", "c|d", "|", "|", "|", "e", "|", "|f|"];
     let i = 0;
-    source
-        .pipe(join("|"))
-        .on("data", part => {
-            expect(part).to.equal(expectedParts[i]);
-            t.pass();
-            i++;
-        })
-        .on("error", t.end)
-        .on("end", t.end);
-
-    source.push("ab|");
-    source.push("c|d");
-    source.push("|");
-    source.push("e");
-    source.push("|f|");
-    source.push(null);
-});
-
-test.cb(
-    "join() joins chunks using the specified separator without breaking up multi-byte characters " +
-        "spanning multiple chunks",
-    t => {
-        t.plan(5);
-        const source = new Readable({ objectMode: true });
-        const expectedParts = ["ø", "|", "ö", "|", "一"];
-        let i = 0;
+    return new Promise((resolve, reject) => {
         source
             .pipe(join("|"))
-            .on("data", part => {
+            .on("data", (part) => {
                 expect(part).to.equal(expectedParts[i]);
                 t.pass();
                 i++;
             })
-            .on("error", t.end)
-            .on("end", t.end);
+            .on("error", reject)
+            .on("end", resolve);
 
-        source.push(Buffer.from("ø").slice(0, 1)); // 2-byte character spanning two chunks
-        source.push(Buffer.from("ø").slice(1, 2));
-        source.push(Buffer.from("ö").slice(0, 1)); // 2-byte character spanning two chunks
-        source.push(Buffer.from("ö").slice(1, 2));
-        source.push(Buffer.from("一").slice(0, 1)); // 3-byte character spanning three chunks
-        source.push(Buffer.from("一").slice(1, 2));
-        source.push(Buffer.from("一").slice(2, 3));
+        source.push("ab|");
+        source.push("c|d");
+        source.push("|");
+        source.push("e");
+        source.push("|f|");
         source.push(null);
+    });
+});
+
+test(
+    "join() joins chunks using the specified separator without breaking up multi-byte characters " +
+        "spanning multiple chunks",
+    (t) => {
+        t.plan(5);
+        const source = new Readable({ objectMode: true });
+        const expectedParts = ["ø", "|", "ö", "|", "一"];
+        let i = 0;
+        return new Promise((resolve, reject) => {
+            source
+                .pipe(join("|"))
+                .on("data", (part) => {
+                    expect(part).to.equal(expectedParts[i]);
+                    t.pass();
+                    i++;
+                })
+                .on("error", reject)
+                .on("end", resolve);
+
+            source.push(Buffer.from("ø").slice(0, 1)); // 2-byte character spanning two chunks
+            source.push(Buffer.from("ø").slice(1, 2));
+            source.push(Buffer.from("ö").slice(0, 1)); // 2-byte character spanning two chunks
+            source.push(Buffer.from("ö").slice(1, 2));
+            source.push(Buffer.from("一").slice(0, 1)); // 3-byte character spanning three chunks
+            source.push(Buffer.from("一").slice(1, 2));
+            source.push(Buffer.from("一").slice(2, 3));
+            source.push(null);
+        });
     },
 );

--- a/tests/map.spec.ts
+++ b/tests/map.spec.ts
@@ -3,7 +3,7 @@ import test from "ava";
 import { expect } from "chai";
 import { map } from "../src";
 
-test.cb("map() maps elements synchronously", t => {
+test("map() maps elements synchronously", (t) => {
     t.plan(3);
     const source = new Readable({ objectMode: true });
     const mapStream = map((element: string) => element.toUpperCase(), {
@@ -11,23 +11,25 @@ test.cb("map() maps elements synchronously", t => {
     });
     const expectedElements = ["A", "B", "C"];
     let i = 0;
-    source
-        .pipe(mapStream)
-        .on("data", (element: string) => {
-            expect(element).to.equal(expectedElements[i]);
-            t.pass();
-            i++;
-        })
-        .on("error", t.end)
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(mapStream)
+            .on("data", (element: string) => {
+                expect(element).to.equal(expectedElements[i]);
+                t.pass();
+                i++;
+            })
+            .on("error", reject)
+            .on("end", resolve);
 
-    source.push("a");
-    source.push("b");
-    source.push("c");
-    source.push(null);
+        source.push("a");
+        source.push("b");
+        source.push("c");
+        source.push(null);
+    });
 });
 
-test.cb("map() maps elements asynchronously", t => {
+test("map() maps elements asynchronously", (t) => {
     t.plan(3);
     const source = new Readable({ objectMode: true });
     const mapStream = map(
@@ -39,18 +41,20 @@ test.cb("map() maps elements asynchronously", t => {
     );
     const expectedElements = ["A", "B", "C"];
     let i = 0;
-    source
-        .pipe(mapStream)
-        .on("data", (element: string) => {
-            expect(element).to.equal(expectedElements[i]);
-            t.pass();
-            i++;
-        })
-        .on("error", t.end)
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(mapStream)
+            .on("data", (element: string) => {
+                expect(element).to.equal(expectedElements[i]);
+                t.pass();
+                i++;
+            })
+            .on("error", reject)
+            .on("end", resolve);
 
-    source.push("a");
-    source.push("b");
-    source.push("c");
-    source.push(null);
+        source.push("a");
+        source.push("b");
+        source.push("c");
+        source.push(null);
+    });
 });

--- a/tests/merge.spec.ts
+++ b/tests/merge.spec.ts
@@ -3,22 +3,21 @@ import test from "ava";
 import { expect } from "chai";
 import { merge } from "../src";
 
-test.cb(
-    "merge() merges multiple readable streams in chunk arrival order",
-    t => {
-        t.plan(6);
-        const source1 = new Readable({ objectMode: true, read: () => ({}) });
-        const source2 = new Readable({ objectMode: true, read: () => ({}) });
-        const expectedElements = ["a", "d", "b", "e", "c", "f"];
-        let i = 0;
+test("merge() merges multiple readable streams in chunk arrival order", (t) => {
+    t.plan(6);
+    const source1 = new Readable({ objectMode: true, read: () => ({}) });
+    const source2 = new Readable({ objectMode: true, read: () => ({}) });
+    const expectedElements = ["a", "d", "b", "e", "c", "f"];
+    let i = 0;
+    return new Promise((resolve, reject) => {
         merge(source1, source2)
             .on("data", (element: string) => {
                 expect(element).to.equal(expectedElements[i]);
                 t.pass();
                 i++;
             })
-            .on("error", t.end)
-            .on("end", t.end);
+            .on("error", reject)
+            .on("end", resolve);
 
         source1.push("a");
         setTimeout(() => source2.push("d"), 10);
@@ -28,33 +27,37 @@ test.cb(
         setTimeout(() => source2.push("f"), 50);
         setTimeout(() => source2.push(null), 60);
         setTimeout(() => source1.push(null), 70);
-    },
-);
+    });
+});
 
-test.cb("merge() merges a readable stream", t => {
+test("merge() merges a readable stream", (t) => {
     t.plan(3);
     const source = new Readable({ objectMode: true, read: () => ({}) });
     const expectedElements = ["a", "b", "c"];
     let i = 0;
-    merge(source)
-        .on("data", (element: string) => {
-            expect(element).to.equal(expectedElements[i]);
-            t.pass();
-            i++;
-        })
-        .on("error", t.end)
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        merge(source)
+            .on("data", (element: string) => {
+                expect(element).to.equal(expectedElements[i]);
+                t.pass();
+                i++;
+            })
+            .on("error", reject)
+            .on("end", resolve);
 
-    source.push("a");
-    source.push("b");
-    source.push("c");
-    source.push(null);
+        source.push("a");
+        source.push("b");
+        source.push("c");
+        source.push(null);
+    });
 });
 
-test.cb("merge() merges an empty list of readable streams", t => {
+test("merge() merges an empty list of readable streams", (t) => {
     t.plan(0);
-    merge()
-        .on("data", () => t.pass())
-        .on("error", t.end)
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        merge()
+            .on("data", () => t.pass())
+            .on("error", reject)
+            .on("end", resolve);
+    });
 });

--- a/tests/parallelMap.spec.ts
+++ b/tests/parallelMap.spec.ts
@@ -5,7 +5,7 @@ import { expect } from "chai";
 import { parallelMap } from "../src";
 import { sleep } from "../src/helpers";
 
-test.cb("parallelMap() parallel mapping", t => {
+test("parallelMap() parallel mapping", (t) => {
     t.plan(6);
     const offset = 50;
     const source = new Readable({ objectMode: true });
@@ -23,55 +23,57 @@ test.cb("parallelMap() parallel mapping", t => {
         finish?: number;
     }
     const orderedResults: IPerfData[] = [];
-    source
-        .pipe(
-            parallelMap(async (data: any) => {
-                const perfData: IPerfData = { start: performance.now() };
-                const c = data + "_processed";
-                perfData.output = c;
-                await sleep(offset);
-                perfData.finish = performance.now();
-                orderedResults.push(perfData);
-                return c;
-            }, 2),
-        )
-        .on("data", (element: string) => {
-            t.true(expectedElements.includes(element));
-        })
-        .on("error", t.end)
-        .on("end", async () => {
-            expect(orderedResults[0].finish).to.be.lessThan(
-                orderedResults[2].start,
-            );
-            expect(orderedResults[1].finish).to.be.lessThan(
-                orderedResults[3].start,
-            );
-            expect(orderedResults[2].finish).to.be.lessThan(
-                orderedResults[4].start,
-            );
-            expect(orderedResults[3].finish).to.be.lessThan(
-                orderedResults[5].start,
-            );
-            expect(orderedResults[0].start).to.be.lessThan(
-                orderedResults[2].start + offset,
-            );
-            expect(orderedResults[1].start).to.be.lessThan(
-                orderedResults[3].start + offset,
-            );
-            expect(orderedResults[2].start).to.be.lessThan(
-                orderedResults[4].start + offset,
-            );
-            expect(orderedResults[3].start).to.be.lessThan(
-                orderedResults[5].start + offset,
-            );
-            t.end();
-        });
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(
+                parallelMap(async (data: any) => {
+                    const perfData: IPerfData = { start: performance.now() };
+                    const c = data + "_processed";
+                    perfData.output = c;
+                    await sleep(offset);
+                    perfData.finish = performance.now();
+                    orderedResults.push(perfData);
+                    return c;
+                }, 2),
+            )
+            .on("data", (element: string) => {
+                t.true(expectedElements.includes(element));
+            })
+            .on("error", reject)
+            .on("end", async () => {
+                expect(orderedResults[0].finish).to.be.lessThan(
+                    orderedResults[2].start,
+                );
+                expect(orderedResults[1].finish).to.be.lessThan(
+                    orderedResults[3].start,
+                );
+                expect(orderedResults[2].finish).to.be.lessThan(
+                    orderedResults[4].start,
+                );
+                expect(orderedResults[3].finish).to.be.lessThan(
+                    orderedResults[5].start,
+                );
+                expect(orderedResults[0].start).to.be.lessThan(
+                    orderedResults[2].start + offset,
+                );
+                expect(orderedResults[1].start).to.be.lessThan(
+                    orderedResults[3].start + offset,
+                );
+                expect(orderedResults[2].start).to.be.lessThan(
+                    orderedResults[4].start + offset,
+                );
+                expect(orderedResults[3].start).to.be.lessThan(
+                    orderedResults[5].start + offset,
+                );
+                resolve();
+            });
 
-    source.push("a");
-    source.push("b");
-    source.push("c");
-    source.push("d");
-    source.push("e");
-    source.push("f");
-    source.push(null);
+        source.push("a");
+        source.push("b");
+        source.push("c");
+        source.push("d");
+        source.push("e");
+        source.push("f");
+        source.push(null);
+    });
 });

--- a/tests/rate.spec.ts
+++ b/tests/rate.spec.ts
@@ -4,7 +4,7 @@ import test from "ava";
 import { rate } from "../src";
 import { sleep } from "../src/helpers";
 
-test.cb("rate() sends data at a rate of 150", t => {
+test("rate() sends data at a rate of 150", (t) => {
     t.plan(15);
     const targetRate = 150;
     const source = new Readable({ objectMode: true });
@@ -12,27 +12,29 @@ test.cb("rate() sends data at a rate of 150", t => {
     const start = performance.now();
     let i = 0;
 
-    source
-        .pipe(rate(targetRate))
-        .on("data", (element: string) => {
-            const currentRate = (i / (performance.now() - start)) * 1000;
-            t.is(element, expectedElements[i]);
-            t.true(currentRate <= targetRate);
-            t.pass();
-            i++;
-        })
-        .on("error", t.end)
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(rate(targetRate))
+            .on("data", (element: string) => {
+                const currentRate = (i / (performance.now() - start)) * 1000;
+                t.is(element, expectedElements[i]);
+                t.true(currentRate <= targetRate);
+                t.pass();
+                i++;
+            })
+            .on("error", reject)
+            .on("end", resolve);
 
-    source.push("a");
-    source.push("b");
-    source.push("c");
-    source.push("d");
-    source.push("e");
-    source.push(null);
+        source.push("a");
+        source.push("b");
+        source.push("c");
+        source.push("d");
+        source.push("e");
+        source.push(null);
+    });
 });
 
-test.cb("rate() sends data at a rate of 50", t => {
+test("rate() sends data at a rate of 50", (t) => {
     t.plan(15);
     const targetRate = 50;
     const source = new Readable({ objectMode: true });
@@ -40,27 +42,29 @@ test.cb("rate() sends data at a rate of 50", t => {
     const start = performance.now();
     let i = 0;
 
-    source
-        .pipe(rate(targetRate))
-        .on("data", (element: string) => {
-            const currentRate = (i / (performance.now() - start)) * 1000;
-            t.is(element, expectedElements[i]);
-            t.true(currentRate <= targetRate);
-            t.pass();
-            i++;
-        })
-        .on("error", t.end)
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(rate(targetRate))
+            .on("data", (element: string) => {
+                const currentRate = (i / (performance.now() - start)) * 1000;
+                t.is(element, expectedElements[i]);
+                t.true(currentRate <= targetRate);
+                t.pass();
+                i++;
+            })
+            .on("error", reject)
+            .on("end", resolve);
 
-    source.push("a");
-    source.push("b");
-    source.push("c");
-    source.push("d");
-    source.push("e");
-    source.push(null);
+        source.push("a");
+        source.push("b");
+        source.push("c");
+        source.push("d");
+        source.push("e");
+        source.push(null);
+    });
 });
 
-test.cb("rate() sends data at a rate of 1", t => {
+test("rate() sends data at a rate of 1", (t) => {
     t.plan(15);
     const targetRate = 1;
     const source = new Readable({ objectMode: true });
@@ -68,27 +72,29 @@ test.cb("rate() sends data at a rate of 1", t => {
     const start = performance.now();
     let i = 0;
 
-    source
-        .pipe(rate(targetRate))
-        .on("data", (element: string) => {
-            const currentRate = (i / (performance.now() - start)) * 1000;
-            t.is(element, expectedElements[i]);
-            t.true(currentRate <= targetRate);
-            t.pass();
-            i++;
-        })
-        .on("error", t.end)
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(rate(targetRate))
+            .on("data", (element: string) => {
+                const currentRate = (i / (performance.now() - start)) * 1000;
+                t.is(element, expectedElements[i]);
+                t.true(currentRate <= targetRate);
+                t.pass();
+                i++;
+            })
+            .on("error", reject)
+            .on("end", resolve);
 
-    source.push("a");
-    source.push("b");
-    source.push("c");
-    source.push("d");
-    source.push("e");
-    source.push(null);
+        source.push("a");
+        source.push("b");
+        source.push("c");
+        source.push("d");
+        source.push("e");
+        source.push(null);
+    });
 });
 
-test("rate() sends data at a rate of 1 and drops extra messages", async t => {
+test("rate() sends data at a rate of 1 and drops extra messages", async (t) => {
     t.plan(9);
     const targetRate = 1;
     const source = new Readable({

--- a/tests/reduce.spec.ts
+++ b/tests/reduce.spec.ts
@@ -3,96 +3,115 @@ import test from "ava";
 import { expect } from "chai";
 import { reduce } from "../src";
 
-test.cb("reduce() reduces elements synchronously", t => {
+test("reduce() reduces elements synchronously", (t) => {
     t.plan(1);
     const source = new Readable({ objectMode: true });
     const expectedValue = 6;
-    source
-        .pipe(reduce((acc: number, element: string) => acc + element.length, 0))
-        .on("data", (element: string) => {
-            expect(element).to.equal(expectedValue);
-            t.pass();
-        })
-        .on("error", t.end)
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(
+                reduce(
+                    (acc: number, element: string) => acc + element.length,
+                    0,
+                ),
+            )
+            .on("data", (element: string) => {
+                expect(element).to.equal(expectedValue);
+                t.pass();
+            })
+            .on("error", reject)
+            .on("end", resolve);
 
-    source.push("ab");
-    source.push("cd");
-    source.push("ef");
-    source.push(null);
+        source.push("ab");
+        source.push("cd");
+        source.push("ef");
+        source.push(null);
+    });
 });
 
-test.cb("reduce() reduces elements asynchronously", t => {
+test("reduce() reduces elements asynchronously", (t) => {
     t.plan(1);
     const source = new Readable({ objectMode: true });
     const expectedValue = 6;
-    source
-        .pipe(
-            reduce(async (acc: number, element: string) => {
-                await Promise.resolve();
-                return acc + element.length;
-            }, 0),
-        )
-        .on("data", (element: string) => {
-            expect(element).to.equal(expectedValue);
-            t.pass();
-        })
-        .on("error", t.end)
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(
+                reduce(async (acc: number, element: string) => {
+                    await Promise.resolve();
+                    return acc + element.length;
+                }, 0),
+            )
+            .on("data", (element: string) => {
+                expect(element).to.equal(expectedValue);
+                t.pass();
+            })
+            .on("error", reject)
+            .on("end", resolve);
 
-    source.push("ab");
-    source.push("cd");
-    source.push("ef");
-    source.push(null);
+        source.push("ab");
+        source.push("cd");
+        source.push("ef");
+        source.push(null);
+    });
 });
 
-test.cb.skip("reduce() emits errors during synchronous reduce", t => {
+test("reduce() emits errors during synchronous reduce", (t) => {
     t.plan(2);
     const source = new Readable({ objectMode: true });
-    source
-        .pipe(
-            reduce((acc: number, element: string) => {
-                if (element !== "ab") {
-                    throw new Error("Failed reduce");
-                }
-                return acc + element.length;
-            }, 0),
-        )
-        .resume()
-        .on("error", err => {
-            expect(err.message).to.equal("Failed reduce");
-            t.pass();
-        })
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(
+                reduce((acc: number, element: string) => {
+                    if (element !== "ab") {
+                        throw new Error("Failed reduce");
+                    }
+                    return acc + element.length;
+                }, 0),
+            )
+            .resume()
+            .on("error", (err) => {
+                expect(err.message).to.equal("Failed reduce");
+                t.pass();
+            })
+            .on("close", () => {
+                t.pass();
+                resolve();
+            });
 
-    source.push("ab");
-    source.push("cd");
-    source.push("ef");
-    source.push(null);
+        source.push("ab");
+        source.push("cd");
+        source.push("ef");
+        source.push(null);
+    });
 });
 
-test.cb.skip("reduce() emits errors during asynchronous reduce", t => {
+test("reduce() emits errors during asynchronous reduce", (t) => {
     t.plan(2);
     const source = new Readable({ objectMode: true });
-    source
-        .pipe(
-            reduce(async (acc: number, element: string) => {
-                await Promise.resolve();
-                if (element !== "ab") {
-                    throw new Error("Failed mapping");
-                }
-                return acc + element.length;
-            }, 0),
-        )
-        .resume()
-        .on("error", err => {
-            expect(err.message).to.equal("Failed mapping");
-            t.pass();
-        })
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(
+                reduce(async (acc: number, element: string) => {
+                    await Promise.resolve();
+                    if (element !== "ab") {
+                        throw new Error("Failed mapping");
+                    }
+                    return acc + element.length;
+                }, 0),
+            )
+            .resume()
+            .on("error", (err) => {
+                expect(err.message).to.equal("Failed mapping");
+                t.pass();
+            })
+            .on("close", () => {
+                t.pass();
+                resolve();
+            });
 
-    source.push("ab");
-    source.push("cd");
-    source.push("ef");
-    source.push(null);
+        source.push("ab");
+        source.push("cd");
+        source.push("ef");
+        source.push(null);
+    });
 });

--- a/tests/replace.spec.ts
+++ b/tests/replace.spec.ts
@@ -3,72 +3,75 @@ import test from "ava";
 import { expect } from "chai";
 import { replace } from "../src";
 
-test.cb(
+test(
     "replace() replaces occurrences of the given string in the streamed elements with the specified " +
         "replacement string",
-    t => {
+    (t) => {
         t.plan(3);
         const source = new Readable({ objectMode: true });
         const expectedElements = ["abc", "xyf", "ghi"];
         let i = 0;
-        source
-            .pipe(replace("de", "xy"))
-            .on("data", part => {
-                expect(part).to.equal(expectedElements[i]);
-                t.pass();
-                i++;
-            })
-            .on("error", t.end)
-            .on("end", t.end);
+        return new Promise((resolve, reject) => {
+            source
+                .pipe(replace("de", "xy"))
+                .on("data", (part) => {
+                    expect(part).to.equal(expectedElements[i]);
+                    t.pass();
+                    i++;
+                })
+                .on("error", reject)
+                .on("end", resolve);
 
-        source.push("abc");
-        source.push("def");
-        source.push("ghi");
-        source.push(null);
+            source.push("abc");
+            source.push("def");
+            source.push("ghi");
+            source.push(null);
+        });
     },
 );
 
-test.cb(
+test(
     "replace() replaces occurrences of the given regular expression in the streamed elements with " +
         "the specified replacement string",
-    t => {
+    (t) => {
         t.plan(3);
         const source = new Readable({ objectMode: true });
         const expectedElements = ["abc", "xyz", "ghi"];
         let i = 0;
-        source
-            .pipe(replace(/^def$/, "xyz"))
-            .on("data", part => {
-                expect(part).to.equal(expectedElements[i]);
-                t.pass();
-                i++;
-            })
-            .on("error", t.end)
-            .on("end", t.end);
+        return new Promise((resolve, reject) => {
+            source
+                .pipe(replace(/^def$/, "xyz"))
+                .on("data", (part) => {
+                    expect(part).to.equal(expectedElements[i]);
+                    t.pass();
+                    i++;
+                })
+                .on("error", reject)
+                .on("end", resolve);
 
-        source.push("abc");
-        source.push("def");
-        source.push("ghi");
-        source.push(null);
+            source.push("abc");
+            source.push("def");
+            source.push("ghi");
+            source.push(null);
+        });
     },
 );
 
-test.cb(
-    "replace() replaces occurrences of the given multi-byte character even if it spans multiple chunks",
-    t => {
-        t.plan(3);
-        const source = new Readable({ objectMode: true });
-        const expectedElements = ["ø", "O", "a"];
-        let i = 0;
+test("replace() replaces occurrences of the given multi-byte character even if it spans multiple chunks", (t) => {
+    t.plan(3);
+    const source = new Readable({ objectMode: true });
+    const expectedElements = ["ø", "O", "a"];
+    let i = 0;
+    return new Promise((resolve, reject) => {
         source
             .pipe(replace("ö", "O"))
-            .on("data", part => {
+            .on("data", (part) => {
                 expect(part).to.equal(expectedElements[i]);
                 t.pass();
                 i++;
             })
-            .on("error", t.end)
-            .on("end", t.end);
+            .on("error", reject)
+            .on("end", resolve);
 
         source.push(Buffer.from("ø").slice(0, 1)); // 2-byte character spanning two chunks
         source.push(Buffer.from("ø").slice(1, 2));
@@ -76,5 +79,5 @@ test.cb(
         source.push(Buffer.from("ö").slice(1, 2));
         source.push("a");
         source.push(null);
-    },
-);
+    });
+});

--- a/tests/split.spec.ts
+++ b/tests/split.spec.ts
@@ -3,96 +3,98 @@ import test from "ava";
 import { expect } from "chai";
 import { split } from "../src";
 
-test.cb("split() splits chunks using the default separator (\\n)", t => {
+test("split() splits chunks using the default separator (\\n)", (t) => {
     t.plan(5);
     const source = new Readable({ objectMode: true });
     const expectedParts = ["ab", "c", "d", "ef", ""];
     let i = 0;
-    source
-        .pipe(split())
-        .on("data", part => {
-            expect(part).to.equal(expectedParts[i]);
-            t.pass();
-            i++;
-        })
-        .on("error", t.end)
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(split())
+            .on("data", (part) => {
+                expect(part).to.equal(expectedParts[i]);
+                t.pass();
+                i++;
+            })
+            .on("error", reject)
+            .on("end", resolve);
 
-    source.push("ab\n");
-    source.push("c");
-    source.push("\n");
-    source.push("d");
-    source.push("\nef\n");
-    source.push(null);
+        source.push("ab\n");
+        source.push("c");
+        source.push("\n");
+        source.push("d");
+        source.push("\nef\n");
+        source.push(null);
+    });
 });
 
-test.cb("split() splits chunks using the specified separator", t => {
+test("split() splits chunks using the specified separator", (t) => {
     t.plan(6);
     const source = new Readable({ objectMode: true });
     const expectedParts = ["ab", "c", "d", "e", "f", ""];
     let i = 0;
-    source
-        .pipe(split("|"))
-        .on("data", (part: string) => {
-            expect(part).to.equal(expectedParts[i]);
-            t.pass();
-            i++;
-        })
-        .on("error", t.end)
-        .on("end", t.end);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(split("|"))
+            .on("data", (part: string) => {
+                expect(part).to.equal(expectedParts[i]);
+                t.pass();
+                i++;
+            })
+            .on("error", reject)
+            .on("end", resolve);
 
-    source.push("ab|");
-    source.push("c|d");
-    source.push("|");
-    source.push("e");
-    source.push("|f|");
-    source.push(null);
+        source.push("ab|");
+        source.push("c|d");
+        source.push("|");
+        source.push("e");
+        source.push("|f|");
+        source.push(null);
+    });
 });
 
-test.cb(
-    "split() splits utf8 encoded buffers using the specified separator",
-    t => {
-        t.plan(3);
-        const expectedElements = ["a", "b", "c"];
-        let i = 0;
-        const through = split(",");
-        const buf = Buffer.from("a,b,c");
+test("split() splits utf8 encoded buffers using the specified separator", (t) => {
+    t.plan(3);
+    const expectedElements = ["a", "b", "c"];
+    let i = 0;
+    const through = split(",");
+    const buf = Buffer.from("a,b,c");
+    return new Promise((resolve, reject) => {
         through
-            .on("data", element => {
+            .on("data", (element) => {
                 expect(element).to.equal(expectedElements[i]);
                 i++;
                 t.pass();
             })
-            .on("error", t.end)
-            .on("end", t.end);
+            .on("error", reject)
+            .on("end", resolve);
 
         for (let j = 0; j < buf.length; ++j) {
             through.write(buf.slice(j, j + 1));
         }
         through.end();
-    },
-);
+    });
+});
 
-test.cb(
-    "split() splits utf8 encoded buffers with multi-byte characters using the specified separator",
-    t => {
-        t.plan(3);
-        const expectedElements = ["一", "一", "一"];
-        let i = 0;
-        const through = split(",");
-        const buf = Buffer.from("一,一,一"); // Those spaces are multi-byte utf8 characters (code: 4E00)
+test("split() splits utf8 encoded buffers with multi-byte characters using the specified separator", (t) => {
+    t.plan(3);
+    const expectedElements = ["一", "一", "一"];
+    let i = 0;
+    const through = split(",");
+    const buf = Buffer.from("一,一,一"); // Those spaces are multi-byte utf8 characters (code: 4E00)
+    return new Promise((resolve, reject) => {
         through
-            .on("data", element => {
+            .on("data", (element) => {
                 expect(element).to.equal(expectedElements[i]);
                 i++;
                 t.pass();
             })
-            .on("error", t.end)
-            .on("end", t.end);
+            .on("error", reject)
+            .on("end", resolve);
 
         for (let j = 0; j < buf.length; ++j) {
             through.write(buf.slice(j, j + 1));
         }
         through.end();
-    },
-);
+    });
+});

--- a/tests/stringify.spec.ts
+++ b/tests/stringify.spec.ts
@@ -3,7 +3,7 @@ import test from "ava";
 import { expect } from "chai";
 import { stringify } from "../src";
 
-test.cb("stringify() stringifies the streamed elements as JSON", t => {
+test("stringify() stringifies the streamed elements as JSON", (t) => {
     t.plan(4);
     const source = new Readable({ objectMode: true });
     const expectedElements = [
@@ -13,49 +13,50 @@ test.cb("stringify() stringifies the streamed elements as JSON", t => {
         '["a","b","c"]',
     ];
     let i = 0;
-    source
-        .pipe(stringify())
-        .on("data", part => {
-            expect(part).to.deep.equal(expectedElements[i]);
-            t.pass();
-            i++;
-        })
-        .on("error", t.end)
-        .on("end", t.end);
-
-    source.push("abc");
-    source.push(0);
-    source.push({ a: "a", b: "b", c: "c" });
-    source.push(["a", "b", "c"]);
-    source.push(null);
-});
-
-test.cb(
-    "stringify() stringifies the streamed elements as pretty-printed JSON",
-    t => {
-        t.plan(4);
-        const source = new Readable({ objectMode: true });
-        const expectedElements = [
-            '"abc"',
-            "0",
-            '{\n  "a": "a",\n  "b": "b",\n  "c": "c"\n}',
-            '[\n  "a",\n  "b",\n  "c"\n]',
-        ];
-        let i = 0;
+    return new Promise((resolve, reject) => {
         source
-            .pipe(stringify({ pretty: true }))
-            .on("data", part => {
+            .pipe(stringify())
+            .on("data", (part) => {
                 expect(part).to.deep.equal(expectedElements[i]);
                 t.pass();
                 i++;
             })
-            .on("error", t.end)
-            .on("end", t.end);
+            .on("error", reject)
+            .on("end", resolve);
 
         source.push("abc");
         source.push(0);
         source.push({ a: "a", b: "b", c: "c" });
         source.push(["a", "b", "c"]);
         source.push(null);
-    },
-);
+    });
+});
+
+test("stringify() stringifies the streamed elements as pretty-printed JSON", (t) => {
+    t.plan(4);
+    const source = new Readable({ objectMode: true });
+    const expectedElements = [
+        '"abc"',
+        "0",
+        '{\n  "a": "a",\n  "b": "b",\n  "c": "c"\n}',
+        '[\n  "a",\n  "b",\n  "c"\n]',
+    ];
+    let i = 0;
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(stringify({ pretty: true }))
+            .on("data", (part) => {
+                expect(part).to.deep.equal(expectedElements[i]);
+                t.pass();
+                i++;
+            })
+            .on("error", reject)
+            .on("end", resolve);
+
+        source.push("abc");
+        source.push(0);
+        source.push({ a: "a", b: "b", c: "c" });
+        source.push(["a", "b", "c"]);
+        source.push(null);
+    });
+});

--- a/tests/unbatch.spec.ts
+++ b/tests/unbatch.spec.ts
@@ -3,24 +3,27 @@ import test from "ava";
 import { expect } from "chai";
 import { unbatch, batch } from "../src";
 
-test.cb("unbatch() unbatches", t => {
+test("unbatch() unbatches", (t) => {
     t.plan(3);
     const source = new Readable({ objectMode: true });
     const expectedElements = ["a", "b", "c"];
     let i = 0;
-    source
-        .pipe(batch(3))
-        .pipe(unbatch())
-        .on("data", (element: string) => {
-            expect(element).to.equal(expectedElements[i]);
-            t.pass();
-            i++;
-        })
-        .on("error", t.end)
-        .on("end", t.end);
 
-    source.push("a");
-    source.push("b");
-    source.push("c");
-    source.push(null);
+    return new Promise((resolve, reject) => {
+        source
+            .pipe(batch(3))
+            .pipe(unbatch())
+            .on("data", (element: string) => {
+                expect(element).to.equal(expectedElements[i]);
+                t.pass();
+                i++;
+            })
+            .on("error", reject)
+            .on("end", resolve);
+
+        source.push("a");
+        source.push("b");
+        source.push("c");
+        source.push(null);
+    });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,80 +2,86 @@
 # yarn lockfile v1
 
 
-"@ava/typescript@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@ava/typescript/-/typescript-1.1.1.tgz#3dcaba3aced8026fdb584d927d809752854dc6e6"
-  integrity sha512-KbLUAe2cWXK63WLK6LnOJonjwEDU/8MNXCOA1ooX/YFZgKRmeAD1kZu+2K0ks5fnOCEcckNQAooyBNGdZUmMQA==
+"@ava/typescript@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@ava/typescript/-/typescript-3.0.1.tgz#b89efbe000b800fa477c9613795b3ca6a53f7112"
+  integrity sha512-/JXIUuKsvkaneaiA9ckk3ksFTqvu0mDNlChASrTe2BnDsvMbhQdPWyqQjJ9WRJWVhhs5TWn1/0Pp1G6Rv8Syrw==
   dependencies:
-    escape-string-regexp "^2.0.0"
+    escape-string-regexp "^5.0.0"
+    execa "^5.1.1"
 
 "@babel/code-frame@^7.0.0":
-  version "7.5.5"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
-  integrity sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.0.tgz#0dfc80309beec8411e65e706461c408b0bb9b431"
+  integrity sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==
   dependencies:
-    "@babel/highlight" "^7.0.0"
+    "@babel/highlight" "^7.16.0"
 
-"@babel/highlight@^7.0.0":
-  version "7.5.0"
-  resolved "https://npm.dev.jogogo.co/@babel%2fhighlight/-/highlight-7.5.0.tgz#56d11312bd9248fa619591d02472be6e8cb32540"
-  integrity sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==
+"@babel/helper-validator-identifier@^7.15.7":
+  version "7.15.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
+  integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
+
+"@babel/highlight@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.0.tgz#6ceb32b2ca4b8f5f361fb7fd821e3fddf4a1725a"
+  integrity sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==
   dependencies:
+    "@babel/helper-validator-identifier" "^7.15.7"
     chalk "^2.0.0"
-    esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@concordance/react@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@concordance/react/-/react-2.0.0.tgz#aef913f27474c53731f4fd79cc2f54897de90fde"
-  integrity sha512-huLSkUuM2/P+U0uy2WwlKuixMsTODD8p4JVQBI4VKeopkiN0C7M3N9XYVawb4M+4spN5RrO/eLhk7KoQX6nsfA==
-  dependencies:
-    arrify "^1.0.1"
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
 
-"@nodelib/fs.scandir@2.1.3":
-  version "2.1.3"
-  resolved "https://npm.dev.jogogo.co/@nodelib%2ffs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
-  integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
   dependencies:
-    "@nodelib/fs.stat" "2.0.3"
+    "@cspotcode/source-map-consumer" "0.8.0"
+
+"@nodelib/fs.scandir@2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
+  integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
-  version "2.0.3"
-  resolved "https://npm.dev.jogogo.co/@nodelib%2ffs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
-  integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
+  integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
 
 "@nodelib/fs.walk@^1.2.3":
-  version "1.2.4"
-  resolved "https://npm.dev.jogogo.co/@nodelib%2ffs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
-  integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
+  integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
   dependencies:
-    "@nodelib/fs.scandir" "2.1.3"
+    "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@sindresorhus/is@^0.14.0":
-  version "0.14.0"
-  resolved "https://npm.dev.jogogo.co/@sindresorhus%2fis/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
-  integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
-
-"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1":
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.2.tgz#858f5c4b48d80778fde4b9d541f27edc0d56488b"
-  integrity sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==
+"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
+  integrity sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/fake-timers@^6.0.0", "@sinonjs/fake-timers@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
-  integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
+"@sinonjs/fake-timers@>=5", "@sinonjs/fake-timers@^9.0.0":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-9.1.0.tgz#8c92c56f195e0bed4c893ba59c8e3d55831ca0df"
+  integrity sha512-M8vapsv9qQupMdzrVzkn5rb9jG7aUTEPAZdMtME2PuBaefksFZVE2C1g4LBRTkF/k3nRDNbDc5tp5NFC1PEYxA==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@sinonjs/samsam@^5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.3.1.tgz#375a45fe6ed4e92fca2fb920e007c48232a6507f"
-  integrity sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==
+"@sinonjs/samsam@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-6.1.1.tgz#627f7f4cbdb56e6419fa2c1a3e4751ce4f6a00b1"
+  integrity sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==
   dependencies:
     "@sinonjs/commons" "^1.6.0"
     lodash.get "^4.4.2"
@@ -83,57 +89,60 @@
 
 "@sinonjs/text-encoding@^0.7.1":
   version "0.7.1"
-  resolved "https://npm.dev.jogogo.co/@sinonjs%2ftext-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@szmarczak/http-timer@^1.1.2":
-  version "1.1.2"
-  resolved "https://npm.dev.jogogo.co/@szmarczak%2fhttp-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
-  integrity sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
-  dependencies:
-    defer-to-connect "^1.0.1"
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
 
-"@types/chai@^4.2.14":
-  version "4.2.14"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.14.tgz#44d2dd0b5de6185089375d976b4ec5caf6861193"
-  integrity sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
 
-"@types/color-name@^1.1.1":
-  version "1.1.1"
-  resolved "https://npm.dev.jogogo.co/@types%2fcolor-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
-  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
 
-"@types/node@^14.14.25":
-  version "14.14.25"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.25.tgz#15967a7b577ff81383f9b888aa6705d43fbbae93"
-  integrity sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
-"@types/normalize-package-data@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
-  integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+"@types/chai@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.0.tgz#23509ebc1fa32f1b4d50d6a66c4032d5b8eaabdc"
+  integrity sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==
 
-"@types/sinon@^9.0.10":
-  version "9.0.10"
-  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-9.0.10.tgz#7fb9bcb6794262482859cab66d59132fca18fcf7"
-  integrity sha512-/faDC0erR06wMdybwI/uR8wEKV/E83T0k4sepIpB7gXuy2gzx2xiOjmztq6a2Y6rIGJ04D+6UU0VBmWy+4HEMA==
+"@types/node@^17.0.17":
+  version "17.0.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.17.tgz#a8ddf6e0c2341718d74ee3dc413a13a042c45a0c"
+  integrity sha512-e8PUNQy1HgJGV3iU/Bp2+D/DXh3PYeyli8LgIwsQcs1Ar1LoaWHSIT6Rw+H2rNJmiq6SNWiDytfx8+gYj7wDHw==
+
+"@types/sinon@^10.0.11":
+  version "10.0.11"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.11.tgz#8245827b05d3fc57a6601bd35aee1f7ad330fc42"
+  integrity sha512-dmZsHlBsKUtBpHriNjlK0ndlvEh8dcb9uV9Afsbt89QIyydpC7NcR+nWlAhASfy3GHnxTl4FX/aKE7XZUt/B4g==
   dependencies:
     "@types/sinonjs__fake-timers" "*"
 
 "@types/sinonjs__fake-timers@*":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz#3a84cf5ec3249439015e14049bd3161419bf9eae"
-  integrity sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.0.tgz#443f49b74f1f57e20d9abac7e18b59e9ee98c5cf"
+  integrity sha512-TZ3vsL7wvXRNTRehor/zKtyWX9Ew3TrT20QQHPx+rieOJivRntZntWhUu1/qKnC8FK4q++RiEl/kje+PAVHhfg==
 
-acorn-walk@^8.0.0:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.0.2.tgz#d4632bfc63fd93d0f15fd05ea0e984ffd3f5a8c3"
-  integrity sha512-+bpA9MJsHdZ4bgfDcpk0ozQyhhVct7rzOmO0s1IIr0AGGgKBljss8n2zp11rRP2wid5VGeh04CgeKzgat5/25A==
+acorn-walk@^8.1.1, acorn-walk@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.0.4:
-  version "8.0.5"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.0.5.tgz#a3bfb872a74a6a7f661bc81b9849d9cac12601b7"
-  integrity sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg==
+acorn@^8.4.1, acorn@^8.7.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -143,26 +152,27 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ansi-align@^3.0.0:
-  version "3.0.0"
-  resolved "https://npm.dev.jogogo.co/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"
-  integrity sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==
+aggregate-error@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-4.0.0.tgz#83dbdb53a0d500721281d22e19eee9bc352a89cd"
+  integrity sha512-8DGp7zUt1E9k0NE2q4jlXHk+V3ORErmwolEdRz9iV+LKJ40WhMHh92cxAvhqV2I+zEn/gotIoqoMs0NjF3xofg==
   dependencies:
-    string-width "^3.0.0"
+    clean-stack "^4.0.0"
+    indent-string "^5.0.0"
 
-ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://npm.dev.jogogo.co/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
-  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+ansi-regex@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
+  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
 ansi-styles@^3.2.1:
   version "3.2.1"
-  resolved "https://npm.dev.jogogo.co/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
@@ -174,35 +184,27 @@ ansi-styles@^4.0.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-styles@^4.1.0:
-  version "4.2.0"
-  resolved "https://npm.dev.jogogo.co/ansi-styles/-/ansi-styles-4.2.0.tgz#5681f0dcf7ae5880a7841d8831c4724ed9cc0172"
-  integrity sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==
-  dependencies:
-    "@types/color-name" "^1.1.1"
-    color-convert "^2.0.1"
+ansi-styles@^6.0.0, ansi-styles@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.1.0.tgz#87313c102b8118abd57371afab34618bf7350ed3"
+  integrity sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ==
 
-ansi-styles@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.1.0.tgz#a436bcc51d81f4fab5080b2ba94242e377c41573"
-  integrity sha512-osxifZo3ar56+e8tdYreU6p8FZGciBHo5O0JoDAxMUqZuyNUb+yHEwYtJZ+Z32R459jEgtwVf1u8D7qYwU0l6w==
-
-anymatch@~3.1.1:
-  version "3.1.1"
-  resolved "https://npm.dev.jogogo.co/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
-  integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
+anymatch@~3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
+  integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
 arg@^4.1.0:
-  version "4.1.2"
-  resolved "https://npm.dev.jogogo.co/arg/-/arg-4.1.2.tgz#e70c90579e02c63d80e3ad4e31d8bfdb8bd50064"
-  integrity sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
-  resolved "https://npm.dev.jogogo.co/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
@@ -214,142 +216,103 @@ array-find-index@^1.0.1:
 
 array-union@^2.1.0:
   version "2.1.0"
-  resolved "https://npm.dev.jogogo.co/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+array-union@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-3.0.1.tgz#da52630d327f8b88cfbfb57728e2af5cd9b6b975"
+  integrity sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==
 
 arrgv@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/arrgv/-/arrgv-1.0.2.tgz#025ed55a6a433cad9b604f8112fc4292715a6ec0"
   integrity sha512-a4eg4yhp7mmruZDQFqVMlxNRFGi/i1r87pt8SDHy0/I8PqSXoUTlWZRdAZo0VXgvEARcujbtTk8kiZRi1uDGRw==
 
-arrify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
-  integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
-
 arrify@^2.0.1:
   version "2.0.1"
-  resolved "https://npm.dev.jogogo.co/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
+
+arrify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-3.0.0.tgz#ccdefb8eaf2a1d2ab0da1ca2ce53118759fd46bc"
+  integrity sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==
 
 assertion-error@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
   integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
-astral-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
-  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
-
-ava@^3.15.0:
-  version "3.15.0"
-  resolved "https://registry.yarnpkg.com/ava/-/ava-3.15.0.tgz#a239658ab1de8a29a243cc902e6b42e4574de2f0"
-  integrity sha512-HGAnk1SHPk4Sx6plFAUkzV/XC1j9+iQhOzt4vBly18/yo0AV8Oytx7mtJd/CR8igCJ5p160N/Oo/cNJi2uSeWA==
+ava@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/ava/-/ava-4.0.1.tgz#dadc24ff5f41f48ff8d5cd9b80a9de9d1ffdf016"
+  integrity sha512-+12A/JDWyShBCZAKISEEPyM2dwkUrrAfPILqXi4LI4Aa58d92PzjY829hmuoSeACPNqrn2Wlbnja8c/n7bKV6Q==
   dependencies:
-    "@concordance/react" "^2.0.0"
-    acorn "^8.0.4"
-    acorn-walk "^8.0.0"
-    ansi-styles "^5.0.0"
+    acorn "^8.7.0"
+    acorn-walk "^8.2.0"
+    ansi-styles "^6.1.0"
     arrgv "^1.0.2"
-    arrify "^2.0.1"
-    callsites "^3.1.0"
-    chalk "^4.1.0"
-    chokidar "^3.4.3"
+    arrify "^3.0.0"
+    callsites "^4.0.0"
+    cbor "^8.1.0"
+    chalk "^5.0.0"
+    chokidar "^3.5.2"
     chunkd "^2.0.1"
-    ci-info "^2.0.0"
+    ci-info "^3.3.0"
     ci-parallel-vars "^1.0.1"
     clean-yaml-object "^0.1.0"
-    cli-cursor "^3.1.0"
-    cli-truncate "^2.1.0"
+    cli-truncate "^3.1.0"
     code-excerpt "^3.0.0"
     common-path-prefix "^3.0.0"
-    concordance "^5.0.1"
-    convert-source-map "^1.7.0"
+    concordance "^5.0.4"
     currently-unhandled "^0.4.1"
-    debug "^4.3.1"
+    debug "^4.3.3"
     del "^6.0.0"
-    emittery "^0.8.0"
-    equal-length "^1.0.0"
-    figures "^3.2.0"
-    globby "^11.0.1"
+    emittery "^0.10.0"
+    figures "^4.0.0"
+    globby "^12.0.2"
     ignore-by-default "^2.0.0"
-    import-local "^3.0.2"
-    indent-string "^4.0.0"
+    indent-string "^5.0.0"
     is-error "^2.2.2"
     is-plain-object "^5.0.0"
     is-promise "^4.0.0"
-    lodash "^4.17.20"
-    matcher "^3.0.0"
-    md5-hex "^3.0.1"
-    mem "^8.0.0"
+    matcher "^5.0.0"
+    mem "^9.0.1"
     ms "^2.1.3"
-    ora "^5.2.0"
-    p-event "^4.2.0"
-    p-map "^4.0.0"
-    picomatch "^2.2.2"
-    pkg-conf "^3.1.0"
-    plur "^4.0.0"
+    p-event "^5.0.1"
+    p-map "^5.3.0"
+    picomatch "^2.3.0"
+    pkg-conf "^4.0.0"
+    plur "^5.1.0"
     pretty-ms "^7.0.1"
-    read-pkg "^5.2.0"
     resolve-cwd "^3.0.0"
     slash "^3.0.0"
-    source-map-support "^0.5.19"
-    stack-utils "^2.0.3"
-    strip-ansi "^6.0.0"
+    stack-utils "^2.0.5"
+    strip-ansi "^7.0.1"
     supertap "^2.0.0"
     temp-dir "^2.0.0"
-    trim-off-newlines "^1.0.1"
-    update-notifier "^5.0.1"
     write-file-atomic "^3.0.3"
-    yargs "^16.2.0"
+    yargs "^17.3.1"
 
 balanced-match@^1.0.0:
-  version "1.0.0"
-  resolved "https://npm.dev.jogogo.co/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
-
-base64-js@^1.3.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 binary-extensions@^2.0.0:
-  version "2.0.0"
-  resolved "https://npm.dev.jogogo.co/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
-  integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
-
-bl@^4.0.3:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.4.tgz#f4fda39f81a811d0df6368c1ed91dae499d1c900"
-  integrity sha512-7tdr4EpSd7jJ6tuQ21vu2ke8w7pNEstzj1O8wwq6sNNzO3UDi5MA8Gny/gquCj7r2C6fHudg8tKRGyjRgmvNxQ==
-  dependencies:
-    buffer "^5.5.0"
-    inherits "^2.0.4"
-    readable-stream "^3.4.0"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
+  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
 blueimp-md5@^2.10.0:
-  version "2.12.0"
-  resolved "https://npm.dev.jogogo.co/blueimp-md5/-/blueimp-md5-2.12.0.tgz#be7367938a889dec3ffbb71138617c117e9c130a"
-  integrity sha512-zo+HIdIhzojv6F1siQPqPFROyVy7C50KzHv/k/Iz+BtvtVzSHXiMXOpq2wCfNkeBqdCv+V8XOV96tsEt2W/3rQ==
-
-boxen@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/boxen/-/boxen-5.0.0.tgz#64fe9b16066af815f51057adcc800c3730120854"
-  integrity sha512-5bvsqw+hhgUi3oYGK0Vf4WpIkyemp60WBInn7+WNfoISzAqk/HX4L7WNROq38E6UR/y3YADpv6pEm4BfkeEAdA==
-  dependencies:
-    ansi-align "^3.0.0"
-    camelcase "^6.2.0"
-    chalk "^4.1.0"
-    cli-boxes "^2.2.1"
-    string-width "^4.2.0"
-    type-fest "^0.20.2"
-    widest-line "^3.1.0"
-    wrap-ansi "^7.0.0"
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/blueimp-md5/-/blueimp-md5-2.19.0.tgz#b53feea5498dcb53dc6ec4b823adb84b729c4af0"
+  integrity sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
-  resolved "https://npm.dev.jogogo.co/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
   integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
   dependencies:
     balanced-match "^1.0.0"
@@ -357,62 +320,39 @@ brace-expansion@^1.1.7:
 
 braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
-  resolved "https://npm.dev.jogogo.co/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
 
-buffer-from@^1.0.0:
-  version "1.1.1"
-  resolved "https://npm.dev.jogogo.co/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
-  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
-
-buffer@^5.5.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
-  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
-  dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.1.13"
-
 builtin-modules@^1.1.1:
   version "1.1.1"
-  resolved "https://npm.dev.jogogo.co/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
   integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
 
-cacheable-request@^6.0.0:
-  version "6.1.0"
-  resolved "https://npm.dev.jogogo.co/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
-  integrity sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==
+callsites@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-4.0.0.tgz#8014cea4fedfe681a30e2f7d2d557dd95808a92a"
+  integrity sha512-y3jRROutgpKdz5vzEhWM34TidDU8vkJppF8dszITeb1PQmSqV3DTxyV8G/lyO/DNvtE1YTedehmw9MPZsCBHxQ==
+
+cbor@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-8.1.0.tgz#cfc56437e770b73417a2ecbfc9caf6b771af60d5"
+  integrity sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==
   dependencies:
-    clone-response "^1.0.2"
-    get-stream "^5.1.0"
-    http-cache-semantics "^4.0.0"
-    keyv "^3.0.0"
-    lowercase-keys "^2.0.0"
-    normalize-url "^4.1.0"
-    responselike "^1.0.2"
+    nofilter "^3.1.0"
 
-callsites@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
-  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
-
-camelcase@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
-  integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
-
-chai@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.0.tgz#5523a5faf7f819c8a92480d70a8cccbadacfc25f"
-  integrity sha512-/BFd2J30EcOwmdOgXvVsmM48l0Br0nmZPlO0uOW4XKh6kpsUumRXBgPV+IlaqFaqr9cYbeoZAM1Npx0i4A+aiA==
+chai@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.6.tgz#ffe4ba2d9fa9d6680cc0b370adae709ec9011e9c"
+  integrity sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==
   dependencies:
     assertion-error "^1.1.0"
     check-error "^1.0.2"
     deep-eql "^3.0.1"
     get-func-name "^2.0.0"
-    pathval "^1.1.0"
+    loupe "^2.3.1"
+    pathval "^1.1.1"
     type-detect "^4.0.5"
 
 chalk@^2.0.0, chalk@^2.3.0:
@@ -424,43 +364,40 @@ chalk@^2.0.0, chalk@^2.3.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
-  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
+chalk@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.0.tgz#bd96c6bb8e02b96e08c0c3ee2a9d90e050c7b832"
+  integrity sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==
 
 check-error@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
-chokidar@^3.4.3:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
-  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
+chokidar@^3.5.2:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
   dependencies:
-    anymatch "~3.1.1"
+    anymatch "~3.1.2"
     braces "~3.0.2"
-    glob-parent "~5.1.0"
+    glob-parent "~5.1.2"
     is-binary-path "~2.1.0"
     is-glob "~4.0.1"
     normalize-path "~3.0.0"
-    readdirp "~3.5.0"
+    readdirp "~3.6.0"
   optionalDependencies:
-    fsevents "~2.3.1"
+    fsevents "~2.3.2"
 
 chunkd@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/chunkd/-/chunkd-2.0.1.tgz#49cd1d7b06992dc4f7fccd962fe2a101ee7da920"
   integrity sha512-7d58XsFmOq0j6el67Ug9mHf9ELUXsQXYJBkyxhH/k+6Ke0qXRnv0kbemx+Twc6fRJ07C49lcbdgm9FL1Ei/6SQ==
 
-ci-info@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
-  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+ci-info@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.0.tgz#b4ed1fb6818dea4803a55c623041f9165d2066b2"
+  integrity sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==
 
 ci-parallel-vars@^1.0.1:
   version "1.0.1"
@@ -472,35 +409,25 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
+clean-stack@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-4.1.0.tgz#5ce5a2fd19a12aecdce8570daefddb7ac94b6b4e"
+  integrity sha512-dxXQYI7mfQVcaF12s6sjNFoZ6ZPDQuBBLp3QJ5156k9EvUFClUoZ11fo8HnLQO241DDVntHEug8MOuFO5PSfRg==
+  dependencies:
+    escape-string-regexp "5.0.0"
+
 clean-yaml-object@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz#63fb110dc2ce1a84dc21f6d9334876d010ae8b68"
   integrity sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=
 
-cli-boxes@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.1.tgz#ddd5035d25094fce220e9cab40a45840a440318f"
-  integrity sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==
-
-cli-cursor@^3.1.0:
+cli-truncate@^3.1.0:
   version "3.1.0"
-  resolved "https://npm.dev.jogogo.co/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
-  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-3.1.0.tgz#3f23ab12535e3d73e839bb43e73c9de487db1389"
+  integrity sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==
   dependencies:
-    restore-cursor "^3.1.0"
-
-cli-spinners@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.5.0.tgz#12763e47251bf951cb75c201dfa58ff1bcb2d047"
-  integrity sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==
-
-cli-truncate@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
-  integrity sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==
-  dependencies:
-    slice-ansi "^3.0.0"
-    string-width "^4.2.0"
+    slice-ansi "^5.0.0"
+    string-width "^5.0.0"
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -511,18 +438,6 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
-clone-response@^1.0.2:
-  version "1.0.2"
-  resolved "https://npm.dev.jogogo.co/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
-  integrity sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
-  dependencies:
-    mimic-response "^1.0.0"
-
-clone@^1.0.2:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
-  integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
-
 code-excerpt@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/code-excerpt/-/code-excerpt-3.0.0.tgz#fcfb6748c03dba8431c19f5474747fad3f250f10"
@@ -532,31 +447,31 @@ code-excerpt@^3.0.0:
 
 color-convert@^1.9.0:
   version "1.9.3"
-  resolved "https://npm.dev.jogogo.co/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
   dependencies:
     color-name "1.1.3"
 
 color-convert@^2.0.1:
   version "2.0.1"
-  resolved "https://npm.dev.jogogo.co/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
 
 color-name@1.1.3:
   version "1.1.3"
-  resolved "https://npm.dev.jogogo.co/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 color-name@~1.1.4:
   version "1.1.4"
-  resolved "https://npm.dev.jogogo.co/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 commander@^2.12.1:
   version "2.20.3"
-  resolved "https://npm.dev.jogogo.co/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 common-path-prefix@^3.0.0:
@@ -566,13 +481,13 @@ common-path-prefix@^3.0.0:
 
 concat-map@0.0.1:
   version "0.0.1"
-  resolved "https://npm.dev.jogogo.co/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concordance@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/concordance/-/concordance-5.0.1.tgz#7a248aca8b286125d1d76f77b03320acf3f4ac63"
-  integrity sha512-TbNtInKVElgEBnJ1v2Xg+MFX2lvFLbmlv3EuSC5wTfCwpB8kC3w3mffF6cKuUhkn475Ym1f1I4qmuXzx2+uXpw==
+concordance@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/concordance/-/concordance-5.0.4.tgz#9896073261adced72f88d60e4d56f8efc4bbbbd2"
+  integrity sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw==
   dependencies:
     date-time "^3.1.0"
     esutils "^2.0.3"
@@ -582,25 +497,6 @@ concordance@^5.0.1:
     md5-hex "^3.0.1"
     semver "^7.3.2"
     well-known-symbols "^2.0.0"
-
-configstore@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/configstore/-/configstore-5.0.1.tgz#d365021b5df4b98cdd187d6a3b0e3f6a7cc5ed96"
-  integrity sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==
-  dependencies:
-    dot-prop "^5.2.0"
-    graceful-fs "^4.1.2"
-    make-dir "^3.0.0"
-    unique-string "^2.0.0"
-    write-file-atomic "^3.0.0"
-    xdg-basedir "^4.0.0"
-
-convert-source-map@^1.7.0:
-  version "1.7.0"
-  resolved "https://npm.dev.jogogo.co/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
-  integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
-  dependencies:
-    safe-buffer "~5.1.1"
 
 convert-to-spaces@^1.0.1:
   version "1.0.2"
@@ -612,10 +508,14 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-crypto-random-string@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
-  integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
+cross-spawn@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -631,19 +531,12 @@ date-time@^3.1.0:
   dependencies:
     time-zone "^1.0.0"
 
-debug@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
-  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+debug@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
   dependencies:
     ms "2.1.2"
-
-decompress-response@^3.3.0:
-  version "3.3.0"
-  resolved "https://npm.dev.jogogo.co/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
-  integrity sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=
-  dependencies:
-    mimic-response "^1.0.0"
 
 deep-eql@^3.0.1:
   version "3.0.1"
@@ -651,23 +544,6 @@ deep-eql@^3.0.1:
   integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
   dependencies:
     type-detect "^4.0.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
-
-defaults@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
-  integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
-  dependencies:
-    clone "^1.0.2"
-
-defer-to-connect@^1.0.1:
-  version "1.1.1"
-  resolved "https://npm.dev.jogogo.co/defer-to-connect/-/defer-to-connect-1.1.1.tgz#88ae694b93f67b81815a2c8c769aef6574ac8f2f"
-  integrity sha512-J7thop4u3mRTkYRQ+Vpfwy2G5Ehoy82I14+14W4YMDLKdWloI9gSzRbV30s/NckQGVJtPkWNcW4oMAUigTdqiQ==
 
 del@^6.0.0:
   version "6.0.0"
@@ -684,77 +560,51 @@ del@^6.0.0:
     slash "^3.0.0"
 
 diff@^4.0.1:
-  version "4.0.1"
-  resolved "https://npm.dev.jogogo.co/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
-  integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
-
-diff@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
+diff@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
+  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+
 dir-glob@^3.0.1:
   version "3.0.1"
-  resolved "https://npm.dev.jogogo.co/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
 
-dot-prop@^5.2.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
-  integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
-  dependencies:
-    is-obj "^2.0.0"
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
-duplexer3@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
-  integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
-
-emittery@^0.8.0:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.8.1.tgz#bb23cc86d03b30aa75a7f734819dee2e1ba70860"
-  integrity sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==
-
-emoji-regex@^7.0.1:
-  version "7.0.3"
-  resolved "https://npm.dev.jogogo.co/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
-  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+emittery@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.10.1.tgz#3d01ab87e2b6542681f8fd6cbd6597a66daa1869"
+  integrity sha512-OBSS9uVXbpgqEGq2V5VnpfCu9vSnfiR9eYVJmxFYToNIcWRHkM4BAFbJe/PWjf/pQdEL7OPxd2jOW/bJiyX7gg==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
-  resolved "https://npm.dev.jogogo.co/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-end-of-stream@^1.1.0:
-  version "1.4.4"
-  resolved "https://npm.dev.jogogo.co/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
-  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
-  dependencies:
-    once "^1.4.0"
-
-equal-length@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/equal-length/-/equal-length-1.0.1.tgz#21ca112d48ab24b4e1e7ffc0e5339d31fdfc274c"
-  integrity sha1-IcoRLUirJLTh5//A5TOdMf38J0w=
-
-error-ex@^1.3.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
-  integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
-  dependencies:
-    is-arrayish "^0.2.1"
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
-escape-goat@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-2.1.1.tgz#1b2dc77003676c457ec760b2dc68edb648188675"
-  integrity sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==
+escape-string-regexp@5.0.0, escape-string-regexp@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
+  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -763,13 +613,8 @@ escape-string-regexp@^1.0.5:
 
 escape-string-regexp@^2.0.0:
   version "2.0.0"
-  resolved "https://npm.dev.jogogo.co/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
-
-escape-string-regexp@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
-  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 eslint-plugin-prettier@^2.2.0:
   version "2.7.0"
@@ -781,13 +626,28 @@ eslint-plugin-prettier@^2.2.0:
 
 esprima@^4.0.0:
   version "4.0.1"
-  resolved "https://npm.dev.jogogo.co/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esutils@^2.0.2, esutils@^2.0.3:
+esutils@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+execa@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
+  integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.0"
+    human-signals "^2.1.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.1"
+    onetime "^5.1.2"
+    signal-exit "^3.0.3"
+    strip-final-newline "^2.0.0"
 
 fast-diff@^1.1.1, fast-diff@^1.2.0:
   version "1.2.0"
@@ -795,62 +655,71 @@ fast-diff@^1.1.1, fast-diff@^1.2.0:
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.1.1:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
-  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
+  integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.0"
+    glob-parent "^5.1.2"
     merge2 "^1.3.0"
-    micromatch "^4.0.2"
-    picomatch "^2.2.1"
+    micromatch "^4.0.4"
+
+fast-glob@^3.2.7:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
 
 fastq@^1.6.0:
-  version "1.6.0"
-  resolved "https://npm.dev.jogogo.co/fastq/-/fastq-1.6.0.tgz#4ec8a38f4ac25f21492673adb7eae9cfef47d1c2"
-  integrity sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
+  integrity sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==
   dependencies:
-    reusify "^1.0.0"
+    reusify "^1.0.4"
 
-figures@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
-  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
+figures@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-4.0.0.tgz#116f140b9d45d1e7a736e7fe80473f1e93f6e4d6"
+  integrity sha512-VnYcWq6H6F0qDN0QnorznBr0abEovifzUokmnezpKZBUbDmbLAt7LMryOp1TKFVxLxyNYkxEkCEADZR58U9oSw==
   dependencies:
-    escape-string-regexp "^1.0.5"
+    escape-string-regexp "^5.0.0"
+    is-unicode-supported "^1.0.0"
 
 fill-range@^7.0.1:
   version "7.0.1"
-  resolved "https://npm.dev.jogogo.co/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
 
-find-up@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
-  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+find-up@^6.0.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-6.3.0.tgz#2abab3d3280b2dc7ac10199ef324c4e002c8c790"
+  integrity sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==
   dependencies:
-    locate-path "^3.0.0"
-
-find-up@^4.0.0:
-  version "4.1.0"
-  resolved "https://npm.dev.jogogo.co/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
-  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
-  dependencies:
-    locate-path "^5.0.0"
-    path-exists "^4.0.0"
+    locate-path "^7.1.0"
+    path-exists "^5.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
-  resolved "https://npm.dev.jogogo.co/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@~2.3.1:
+fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
 get-caller-file@^2.0.5:
   version "2.0.5"
@@ -862,31 +731,22 @@ get-func-name@^2.0.0:
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
   integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
-get-stream@^4.1.0:
-  version "4.1.0"
-  resolved "https://npm.dev.jogogo.co/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
-  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
-  dependencies:
-    pump "^3.0.0"
+get-stream@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
+  integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
-get-stream@^5.1.0:
-  version "5.1.0"
-  resolved "https://npm.dev.jogogo.co/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
-  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
-  dependencies:
-    pump "^3.0.0"
-
-glob-parent@^5.1.0, glob-parent@~5.1.0:
-  version "5.1.0"
-  resolved "https://npm.dev.jogogo.co/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
-  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
+glob-parent@^5.1.2, glob-parent@~5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.1.1:
-  version "7.1.6"
-  resolved "https://npm.dev.jogogo.co/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+glob@^7.1.1, glob@^7.1.3:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -894,30 +754,11 @@ glob@^7.1.1:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-glob@^7.1.3:
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
-  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-global-dirs@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-3.0.0.tgz#70a76fe84ea315ab37b1f5576cbde7d48ef72686"
-  integrity sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==
-  dependencies:
-    ini "2.0.0"
 
 globby@^11.0.1:
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.2.tgz#1af538b766a3b540ebfb58a32b2e2d5897321d83"
-  integrity sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
+  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
   dependencies:
     array-union "^2.1.0"
     dir-glob "^3.0.1"
@@ -926,62 +767,44 @@ globby@^11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-got@^9.6.0:
-  version "9.6.0"
-  resolved "https://npm.dev.jogogo.co/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
-  integrity sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==
+globby@^12.0.2:
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-12.2.0.tgz#2ab8046b4fba4ff6eede835b29f678f90e3d3c22"
+  integrity sha512-wiSuFQLZ+urS9x2gGPl1H5drc5twabmm4m2gTR27XDFyjUHJUNsS8o/2aKyIF6IoBaR630atdher0XJ5g6OMmA==
   dependencies:
-    "@sindresorhus/is" "^0.14.0"
-    "@szmarczak/http-timer" "^1.1.2"
-    cacheable-request "^6.0.0"
-    decompress-response "^3.3.0"
-    duplexer3 "^0.1.4"
-    get-stream "^4.1.0"
-    lowercase-keys "^1.0.1"
-    mimic-response "^1.0.1"
-    p-cancelable "^1.0.0"
-    to-readable-stream "^1.0.0"
-    url-parse-lax "^3.0.0"
-
-graceful-fs@^4.1.15, graceful-fs@^4.1.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
-  integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
+    array-union "^3.0.1"
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.7"
+    ignore "^5.1.9"
+    merge2 "^1.4.1"
+    slash "^4.0.0"
 
 graceful-fs@^4.2.4:
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.5.tgz#bc18864a6c9fc7b303f2e2abdb9155ad178fbe29"
-  integrity sha512-kBBSQbz2K0Nyn+31j/w36fUfxkBW9/gfwRWdUY1ULReH3iokVJgddZAFcD1D0xlgTmFxJCbUkUclAlc6/IDJkw==
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
+  integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
 has-flag@^3.0.0:
   version "3.0.0"
-  resolved "https://npm.dev.jogogo.co/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
 has-flag@^4.0.0:
   version "4.0.0"
-  resolved "https://npm.dev.jogogo.co/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-yarn@^2.1.0:
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
+
+human-signals@^2.1.0:
   version "2.1.0"
-  resolved "https://npm.dev.jogogo.co/has-yarn/-/has-yarn-2.1.0.tgz#137e11354a7b5bf11aa5cb649cf0c6f3ff2b2e77"
-  integrity sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==
-
-hosted-git-info@^2.1.4:
-  version "2.8.4"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.4.tgz#44119abaf4bc64692a16ace34700fed9c03e2546"
-  integrity sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==
-
-http-cache-semantics@^4.0.0:
-  version "4.0.3"
-  resolved "https://npm.dev.jogogo.co/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz#495704773277eeef6e43f9ab2c2c7d259dda25c5"
-  integrity sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==
-
-ieee754@^1.1.13:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
 ignore-by-default@^2.0.0:
   version "2.0.0"
@@ -989,22 +812,14 @@ ignore-by-default@^2.0.0:
   integrity sha512-+mQSgMRiFD3L3AOxLYOCxjIq4OnAmo5CIuC+lj5ehCJcPtV++QacEV7FdpzvYxH6DaOySWzQU6RR0lPLy37ckA==
 
 ignore@^5.1.4:
-  version "5.1.8"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
-  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
+  integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
 
-import-lazy@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
-  integrity sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=
-
-import-local@^3.0.2:
-  version "3.0.2"
-  resolved "https://npm.dev.jogogo.co/import-local/-/import-local-3.0.2.tgz#a8cfd0431d1de4a2199703d003e3e62364fa6db6"
-  integrity sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==
-  dependencies:
-    pkg-dir "^4.2.0"
-    resolve-cwd "^3.0.0"
+ignore@^5.1.9:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
+  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -1013,59 +828,49 @@ imurmurhash@^0.1.4:
 
 indent-string@^4.0.0:
   version "4.0.0"
-  resolved "https://npm.dev.jogogo.co/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
+indent-string@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-5.0.0.tgz#4fd2980fccaf8622d14c64d694f4cf33c81951a5"
+  integrity sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==
 
 inflight@^1.0.4:
   version "1.0.6"
-  resolved "https://npm.dev.jogogo.co/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
   integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
   dependencies:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@^2.0.4:
+inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
-  integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
-
-ini@~1.3.0:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
-
-irregular-plurals@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-3.2.0.tgz#b19c490a0723798db51b235d7e39add44dab0822"
-  integrity sha512-YqTdPLfwP7YFN0SsD3QUVCkm9ZG2VzOXv3DOrw5G5mkMbVwptTwVcFv7/C0vOpBmgTxAeTG19XpUs1E522LW9Q==
-
-is-arrayish@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
-  integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+irregular-plurals@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-3.3.0.tgz#67d0715d4361a60d9fd9ee80af3881c631a31ee2"
+  integrity sha512-MVBLKUTangM3EfRPFROhmWQQKRDsrgI83J8GS3jXy+OwYqiR2/aoWndYQ5416jLE3uaGgLH7ncme3X9y09gZ3g==
 
 is-binary-path@~2.1.0:
   version "2.1.0"
-  resolved "https://npm.dev.jogogo.co/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
 
-is-ci@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
-  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
+is-core-module@^2.2.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.0.tgz#0321336c3d0925e497fd97f5d95cb114a5ccd548"
+  integrity sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==
   dependencies:
-    ci-info "^2.0.0"
+    has "^1.0.3"
 
 is-error@^2.2.2:
   version "2.2.2"
-  resolved "https://npm.dev.jogogo.co/is-error/-/is-error-2.2.2.tgz#c10ade187b3c93510c5470a5567833ee25649843"
+  resolved "https://registry.yarnpkg.com/is-error/-/is-error-2.2.2.tgz#c10ade187b3c93510c5470a5567833ee25649843"
   integrity sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg==
 
 is-extglob@^2.1.1:
@@ -1073,50 +878,27 @@ is-extglob@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
-is-fullwidth-code-point@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-  integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
-
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
-  resolved "https://npm.dev.jogogo.co/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
+is-fullwidth-code-point@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz#fae3167c729e7463f8461ce512b080a49268aa88"
+  integrity sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==
+
 is-glob@^4.0.1, is-glob@~4.0.1:
-  version "4.0.1"
-  resolved "https://npm.dev.jogogo.co/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
-  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
 
-is-installed-globally@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz#9a0fd407949c30f86eb6959ef1b7994ed0b7b520"
-  integrity sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==
-  dependencies:
-    global-dirs "^3.0.0"
-    is-path-inside "^3.0.2"
-
-is-interactive@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
-  integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
-
-is-npm@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-5.0.0.tgz#43e8d65cc56e1b67f8d47262cf667099193f45a8"
-  integrity sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==
-
 is-number@^7.0.0:
   version "7.0.0"
-  resolved "https://npm.dev.jogogo.co/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
-
-is-obj@^2.0.0:
-  version "2.0.0"
-  resolved "https://npm.dev.jogogo.co/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
-  integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
 
 is-path-cwd@^2.2.0:
   version "2.2.0"
@@ -1124,9 +906,9 @@ is-path-cwd@^2.2.0:
   integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
 
 is-path-inside@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz#f5220fc82a3e233757291dddc9c5877f2a1f3017"
-  integrity sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-plain-object@^5.0.0:
   version "5.0.0"
@@ -1138,20 +920,30 @@ is-promise@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
   integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
 
+is-stream@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
 is-typedarray@^1.0.0:
   version "1.0.0"
-  resolved "https://npm.dev.jogogo.co/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
-is-yarn-global@^0.3.0:
-  version "0.3.0"
-  resolved "https://npm.dev.jogogo.co/is-yarn-global/-/is-yarn-global-0.3.0.tgz#d502d3382590ea3004893746754c89139973e232"
-  integrity sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==
+is-unicode-supported@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-1.1.0.tgz#9127b71f9fa82f52ca5c20e982e7bec0ee31ee1e"
+  integrity sha512-lDcxivp8TJpLG75/DpatAqNzOpDPSpED8XNtrpBHTdQ2InQ1PbW78jhwSxyxhhu+xbVSast2X38bwj8atwoUQA==
 
 isarray@0.0.1:
   version "0.0.1"
-  resolved "https://npm.dev.jogogo.co/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
   integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 jest-docblock@^21.0.0:
   version "21.2.0"
@@ -1165,18 +957,10 @@ js-string-escape@^1.0.1:
 
 js-tokens@^4.0.0:
   version "4.0.0"
-  resolved "https://npm.dev.jogogo.co/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
-  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@^3.14.0:
+js-yaml@^3.13.1, js-yaml@^3.14.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -1184,70 +968,27 @@ js-yaml@^3.14.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-json-buffer@3.0.0:
-  version "3.0.0"
-  resolved "https://npm.dev.jogogo.co/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
-  integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
-
-json-parse-better-errors@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
-  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
-
-json-parse-even-better-errors@^2.3.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
-  integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
-
 just-extend@^4.0.2:
-  version "4.0.2"
-  resolved "https://npm.dev.jogogo.co/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
-  integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
-
-keyv@^3.0.0:
-  version "3.1.0"
-  resolved "https://npm.dev.jogogo.co/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
-  integrity sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==
-  dependencies:
-    json-buffer "3.0.0"
-
-latest-version@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
-  integrity sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==
-  dependencies:
-    package-json "^6.3.0"
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
+  integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
 
 lines-and-columns@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
-  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
+  integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-load-json-file@^5.2.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-5.3.0.tgz#4d3c1e01fa1c03ea78a60ac7af932c9ce53403f3"
-  integrity sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==
-  dependencies:
-    graceful-fs "^4.1.15"
-    parse-json "^4.0.0"
-    pify "^4.0.1"
-    strip-bom "^3.0.0"
-    type-fest "^0.3.0"
+load-json-file@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-7.0.1.tgz#a3c9fde6beffb6bedb5acf104fad6bb1604e1b00"
+  integrity sha512-Gnxj3ev3mB5TkVBGad0JM6dmLiQL+o0t23JPBZ9sd+yvSLk05mFoqKBw5N8gbbkU4TNXyqCgIrl/VM17OgUIgQ==
 
-locate-path@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
-  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+locate-path@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-7.1.0.tgz#241d62af60739f6097c055efe10329c88b798425"
+  integrity sha512-HNx5uOnYeK4SxEoid5qnhRfprlJeGMzFRKPLCf/15N3/B4AiofNwC/yq7VBKdVk9dx7m+PiYCJOGg55JYTAqoQ==
   dependencies:
-    p-locate "^3.0.0"
-    path-exists "^3.0.0"
-
-locate-path@^5.0.0:
-  version "5.0.0"
-  resolved "https://npm.dev.jogogo.co/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
-  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
-  dependencies:
-    p-locate "^4.1.0"
+    p-locate "^6.0.0"
 
 lodash.get@^4.4.2:
   version "4.4.2"
@@ -1255,31 +996,16 @@ lodash.get@^4.4.2:
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-lodash@^4.17.20:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-
-log-symbols@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
-  integrity sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==
+loupe@^2.3.1:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.4.tgz#7e0b9bffc76f148f9be769cb1321d3dcf3cb25f3"
+  integrity sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==
   dependencies:
-    chalk "^4.0.0"
-
-lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
-  version "1.0.1"
-  resolved "https://npm.dev.jogogo.co/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
-  integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
-
-lowercase-keys@^2.0.0:
-  version "2.0.0"
-  resolved "https://npm.dev.jogogo.co/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
-  integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
+    get-func-name "^2.0.0"
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -1288,17 +1014,10 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-make-dir@^3.0.0:
-  version "3.0.0"
-  resolved "https://npm.dev.jogogo.co/make-dir/-/make-dir-3.0.0.tgz#1b5f39f6b9270ed33f9f054c5c0f84304989f801"
-  integrity sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==
-  dependencies:
-    semver "^6.0.0"
-
 make-error@^1.1.1:
-  version "1.3.5"
-  resolved "https://npm.dev.jogogo.co/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
-  integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 map-age-cleaner@^0.1.3:
   version "0.1.3"
@@ -1307,67 +1026,62 @@ map-age-cleaner@^0.1.3:
   dependencies:
     p-defer "^1.0.0"
 
-matcher@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/matcher/-/matcher-3.0.0.tgz#bd9060f4c5b70aa8041ccc6f80368760994f30ca"
-  integrity sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==
+matcher@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/matcher/-/matcher-5.0.0.tgz#cd82f1c7ae7ee472a9eeaf8ec7cac45e0fe0da62"
+  integrity sha512-s2EMBOWtXFc8dgqvoAzKJXxNHibcdJMV0gwqKUaw9E2JBJuGUK7DrNKrA6g/i+v72TT16+6sVm5mS3thaMLQUw==
   dependencies:
-    escape-string-regexp "^4.0.0"
+    escape-string-regexp "^5.0.0"
 
 md5-hex@^3.0.1:
   version "3.0.1"
-  resolved "https://npm.dev.jogogo.co/md5-hex/-/md5-hex-3.0.1.tgz#be3741b510591434b2784d79e556eefc2c9a8e5c"
+  resolved "https://registry.yarnpkg.com/md5-hex/-/md5-hex-3.0.1.tgz#be3741b510591434b2784d79e556eefc2c9a8e5c"
   integrity sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==
   dependencies:
     blueimp-md5 "^2.10.0"
 
-mem@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-8.0.0.tgz#b5e4b6d2d241c6296da05436173b4d0c7ae1f9ac"
-  integrity sha512-qrcJOe6uD+EW8Wrci1Vdiua/15Xw3n/QnaNXE7varnB6InxSk7nu3/i5jfy3S6kWxr8WYJ6R1o0afMUtvorTsA==
+mem@^9.0.1:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-9.0.2.tgz#bbc2d40be045afe30749681e8f5d554cee0c0354"
+  integrity sha512-F2t4YIv9XQUBHt6AOJ0y7lSmP1+cY7Fm1DRh9GClTGzKST7UWLMx6ly9WZdLH/G/ppM5RL4MlQfRT71ri9t19A==
   dependencies:
     map-age-cleaner "^0.1.3"
-    mimic-fn "^3.1.0"
+    mimic-fn "^4.0.0"
 
-merge2@^1.3.0:
-  version "1.3.0"
-  resolved "https://npm.dev.jogogo.co/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
-  integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
+merge-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-micromatch@^4.0.2:
-  version "4.0.2"
-  resolved "https://npm.dev.jogogo.co/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
-  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+merge2@^1.3.0, merge2@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micromatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
+  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
   dependencies:
     braces "^3.0.1"
-    picomatch "^2.0.5"
+    picomatch "^2.2.3"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
-  resolved "https://npm.dev.jogogo.co/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-mimic-fn@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.1.0.tgz#65755145bbf3e36954b949c16450427451d5ca74"
-  integrity sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
-
-mimic-response@^1.0.0, mimic-response@^1.0.1:
-  version "1.0.1"
-  resolved "https://npm.dev.jogogo.co/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
-  integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
+mimic-fn@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
+  integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
 
 minimatch@^3.0.4:
   version "3.0.4"
-  resolved "https://npm.dev.jogogo.co/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
-
-minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
 minimist@^1.2.5:
   version "1.2.5"
@@ -1391,114 +1105,73 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nise@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-4.0.4.tgz#d73dea3e5731e6561992b8f570be9e363c4512dd"
-  integrity sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==
+nise@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.1.tgz#ac4237e0d785ecfcb83e20f389185975da5c31f3"
+  integrity sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==
   dependencies:
-    "@sinonjs/commons" "^1.7.0"
-    "@sinonjs/fake-timers" "^6.0.0"
+    "@sinonjs/commons" "^1.8.3"
+    "@sinonjs/fake-timers" ">=5"
     "@sinonjs/text-encoding" "^0.7.1"
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
 
-normalize-package-data@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
-  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
-  dependencies:
-    hosted-git-info "^2.1.4"
-    resolve "^1.10.0"
-    semver "2 || 3 || 4 || 5"
-    validate-npm-package-license "^3.0.1"
+nofilter@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-3.1.0.tgz#c757ba68801d41ff930ba2ec55bab52ca184aa66"
+  integrity sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-normalize-url@^4.1.0:
-  version "4.5.0"
-  resolved "https://npm.dev.jogogo.co/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
-  integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
+npm-run-path@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
+  dependencies:
+    path-key "^3.0.0"
 
-once@^1.3.0, once@^1.3.1, once@^1.4.0:
+once@^1.3.0:
   version "1.4.0"
-  resolved "https://npm.dev.jogogo.co/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
 
-onetime@^5.1.0:
-  version "5.1.0"
-  resolved "https://npm.dev.jogogo.co/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
-  integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
+onetime@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
-
-ora@^5.2.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-5.3.0.tgz#fb832899d3a1372fe71c8b2c534bbfe74961bb6f"
-  integrity sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==
-  dependencies:
-    bl "^4.0.3"
-    chalk "^4.1.0"
-    cli-cursor "^3.1.0"
-    cli-spinners "^2.5.0"
-    is-interactive "^1.0.0"
-    log-symbols "^4.0.0"
-    strip-ansi "^6.0.0"
-    wcwidth "^1.0.1"
-
-p-cancelable@^1.0.0:
-  version "1.1.0"
-  resolved "https://npm.dev.jogogo.co/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
-  integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
 
 p-defer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
   integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
 
-p-event@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/p-event/-/p-event-4.2.0.tgz#af4b049c8acd91ae81083ebd1e6f5cae2044c1b5"
-  integrity sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==
+p-event@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/p-event/-/p-event-5.0.1.tgz#614624ec02ae7f4f13d09a721c90586184af5b0c"
+  integrity sha512-dd589iCQ7m1L0bmC5NLlVYfy3TbBEsMUfWx9PyAgPeIcFZ/E2yaTZ4Rz4MiBmmJShviiftHVXOqfnfzJ6kyMrQ==
   dependencies:
-    p-timeout "^3.1.0"
+    p-timeout "^5.0.2"
 
-p-finally@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
-  integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
-
-p-limit@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
-  integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
+p-limit@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-4.0.0.tgz#914af6544ed32bfa54670b061cafcbd04984b644"
+  integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
   dependencies:
-    p-try "^2.0.0"
+    yocto-queue "^1.0.0"
 
-p-limit@^2.2.0:
-  version "2.2.1"
-  resolved "https://npm.dev.jogogo.co/p-limit/-/p-limit-2.2.1.tgz#aa07a788cc3151c939b5131f63570f0dd2009537"
-  integrity sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==
+p-locate@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-6.0.0.tgz#3da9a49d4934b901089dca3302fa65dc5a05c04f"
+  integrity sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==
   dependencies:
-    p-try "^2.0.0"
-
-p-locate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
-  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
-  dependencies:
-    p-limit "^2.0.0"
-
-p-locate@^4.1.0:
-  version "4.1.0"
-  resolved "https://npm.dev.jogogo.co/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
-  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
-  dependencies:
-    p-limit "^2.2.0"
+    p-limit "^4.0.0"
 
 p-map@^4.0.0:
   version "4.0.0"
@@ -1507,134 +1180,89 @@ p-map@^4.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
-p-timeout@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
-  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
+p-map@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-5.3.0.tgz#2204823bc9f37f17ddc9e7f446293c4530b8a4cf"
+  integrity sha512-SRbIQFoLYNezHkqZslqeg963HYUtqOrfMCxjNrFOpJ19WTYuq26rQoOXeX8QQiMLUlLqdYV/7PuDsdYJ7hLE1w==
   dependencies:
-    p-finally "^1.0.0"
+    aggregate-error "^4.0.0"
 
-p-try@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
-  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
-
-package-json@^6.3.0:
-  version "6.5.0"
-  resolved "https://npm.dev.jogogo.co/package-json/-/package-json-6.5.0.tgz#6feedaca35e75725876d0b0e64974697fed145b0"
-  integrity sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==
-  dependencies:
-    got "^9.6.0"
-    registry-auth-token "^4.0.0"
-    registry-url "^5.0.0"
-    semver "^6.2.0"
-
-parse-json@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
-  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
-  dependencies:
-    error-ex "^1.3.1"
-    json-parse-better-errors "^1.0.1"
-
-parse-json@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
-  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    error-ex "^1.3.1"
-    json-parse-even-better-errors "^2.3.0"
-    lines-and-columns "^1.1.6"
+p-timeout@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-5.0.2.tgz#d12964c4b2f988e15f72b455c2c428d82a0ec0a0"
+  integrity sha512-sEmji9Yaq+Tw+STwsGAE56hf7gMy9p0tQfJojIAamB7WHJYJKf1qlsg9jqBWG8q9VCxKPhZaP/AcXwEoBcYQhQ==
 
 parse-ms@^2.1.0:
   version "2.1.0"
-  resolved "https://npm.dev.jogogo.co/parse-ms/-/parse-ms-2.1.0.tgz#348565a753d4391fa524029956b172cb7753097d"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-2.1.0.tgz#348565a753d4391fa524029956b172cb7753097d"
   integrity sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==
 
-path-exists@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
-  integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
-
-path-exists@^4.0.0:
-  version "4.0.0"
-  resolved "https://npm.dev.jogogo.co/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
-  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+path-exists@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-5.0.0.tgz#a6aad9489200b21fab31e49cf09277e5116fb9e7"
+  integrity sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
-  resolved "https://npm.dev.jogogo.co/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
+path-key@^3.0.0, path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
 path-parse@^1.0.6:
-  version "1.0.6"
-  resolved "https://npm.dev.jogogo.co/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
-  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-to-regexp@^1.7.0:
   version "1.8.0"
-  resolved "https://npm.dev.jogogo.co/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
   integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
   dependencies:
     isarray "0.0.1"
 
 path-type@^4.0.0:
   version "4.0.0"
-  resolved "https://npm.dev.jogogo.co/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-pathval@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
-  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
-picomatch@^2.0.4, picomatch@^2.0.5:
-  version "2.1.1"
-  resolved "https://npm.dev.jogogo.co/picomatch/-/picomatch-2.1.1.tgz#ecdfbea7704adb5fe6fb47f9866c4c0e15e905c5"
-  integrity sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
+  integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
 
-picomatch@^2.2.1, picomatch@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
-  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+picomatch@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-pify@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
-  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
-
-pkg-conf@^3.1.0:
-  version "3.1.0"
-  resolved "https://npm.dev.jogogo.co/pkg-conf/-/pkg-conf-3.1.0.tgz#d9f9c75ea1bae0e77938cde045b276dac7cc69ae"
-  integrity sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==
-  dependencies:
-    find-up "^3.0.0"
-    load-json-file "^5.2.0"
-
-pkg-dir@^4.2.0:
-  version "4.2.0"
-  resolved "https://npm.dev.jogogo.co/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
-  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
-  dependencies:
-    find-up "^4.0.0"
-
-plur@^4.0.0:
+pkg-conf@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/plur/-/plur-4.0.0.tgz#729aedb08f452645fe8c58ef115bf16b0a73ef84"
-  integrity sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==
+  resolved "https://registry.yarnpkg.com/pkg-conf/-/pkg-conf-4.0.0.tgz#63ace00cbacfa94c2226aee133800802d3e3b80c"
+  integrity sha512-7dmgi4UY4qk+4mj5Cd8v/GExPo0K+SlY+hulOSdfZ/T6jVH6//y7NtzZo5WrfhDBxuQ0jCa7fLZmNaNh7EWL/w==
   dependencies:
-    irregular-plurals "^3.2.0"
+    find-up "^6.0.0"
+    load-json-file "^7.0.0"
 
-prepend-http@^2.0.0:
-  version "2.0.0"
-  resolved "https://npm.dev.jogogo.co/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
-  integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+plur@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/plur/-/plur-5.1.0.tgz#bff58c9f557b9061d60d8ebf93959cf4b08594ae"
+  integrity sha512-VP/72JeXqak2KiOzjgKtQen5y3IZHn+9GOuLDafPv0eXa47xq0At93XahYBs26MsifCQ4enGKwbjBTKgb9QJXg==
+  dependencies:
+    irregular-plurals "^3.3.0"
 
-prettier@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+prettier@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
 
 pretty-ms@^7.0.1:
   version "7.0.1"
@@ -1643,71 +1271,17 @@ pretty-ms@^7.0.1:
   dependencies:
     parse-ms "^2.1.0"
 
-pump@^3.0.0:
-  version "3.0.0"
-  resolved "https://npm.dev.jogogo.co/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
-  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
+queue-microtask@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
+  integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-pupa@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/pupa/-/pupa-2.1.1.tgz#f5e8fd4afc2c5d97828faa523549ed8744a20d62"
-  integrity sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==
-  dependencies:
-    escape-goat "^2.0.0"
-
-rc@^1.2.8:
-  version "1.2.8"
-  resolved "https://npm.dev.jogogo.co/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
-read-pkg@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
-  integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
-  dependencies:
-    "@types/normalize-package-data" "^2.4.0"
-    normalize-package-data "^2.5.0"
-    parse-json "^5.0.0"
-    type-fest "^0.6.0"
-
-readable-stream@^3.4.0:
+readdirp@~3.6.0:
   version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
-
-readdirp@~3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
-  integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
-
-registry-auth-token@^4.0.0:
-  version "4.0.0"
-  resolved "https://npm.dev.jogogo.co/registry-auth-token/-/registry-auth-token-4.0.0.tgz#30e55961eec77379da551ea5c4cf43cbf03522be"
-  integrity sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==
-  dependencies:
-    rc "^1.2.8"
-    safe-buffer "^5.0.1"
-
-registry-url@^5.0.0:
-  version "5.1.0"
-  resolved "https://npm.dev.jogogo.co/registry-url/-/registry-url-5.1.0.tgz#e98334b50d5434b81136b44ec638d9c2009c5009"
-  integrity sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==
-  dependencies:
-    rc "^1.2.8"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -1716,48 +1290,27 @@ require-directory@^2.1.1:
 
 resolve-cwd@^3.0.0:
   version "3.0.0"
-  resolved "https://npm.dev.jogogo.co/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
   integrity sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
   dependencies:
     resolve-from "^5.0.0"
 
 resolve-from@^5.0.0:
   version "5.0.0"
-  resolved "https://npm.dev.jogogo.co/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve@^1.10.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
-  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
-  dependencies:
-    path-parse "^1.0.6"
-
 resolve@^1.3.2:
-  version "1.13.1"
-  resolved "https://npm.dev.jogogo.co/resolve/-/resolve-1.13.1.tgz#be0aa4c06acd53083505abb35f4d66932ab35d16"
-  integrity sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
+  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
   dependencies:
+    is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
-responselike@^1.0.2:
-  version "1.0.2"
-  resolved "https://npm.dev.jogogo.co/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
-  integrity sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=
-  dependencies:
-    lowercase-keys "^1.0.0"
-
-restore-cursor@^3.1.0:
-  version "3.1.0"
-  resolved "https://npm.dev.jogogo.co/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
-  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
-  dependencies:
-    onetime "^5.1.0"
-    signal-exit "^3.0.2"
-
-reusify@^1.0.0:
+reusify@^1.0.4:
   version "1.0.4"
-  resolved "https://npm.dev.jogogo.co/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
 rimraf@^3.0.2:
@@ -1768,46 +1321,21 @@ rimraf@^3.0.2:
     glob "^7.1.3"
 
 run-parallel@^1.1.9:
-  version "1.1.9"
-  resolved "https://npm.dev.jogogo.co/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
-  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
-
-safe-buffer@^5.0.1:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
-  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
-
-safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
-semver-diff@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-3.1.1.tgz#05f77ce59f325e00e2706afd67bb506ddb1ca32b"
-  integrity sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
+  integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
-    semver "^6.3.0"
+    queue-microtask "^1.2.2"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0:
+semver@^5.3.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://npm.dev.jogogo.co/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.3.2, semver@^7.3.4:
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
-  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+semver@^7.3.2:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -1818,139 +1346,109 @@ serialize-error@^7.0.1:
   dependencies:
     type-fest "^0.13.1"
 
-signal-exit@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
-  integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
-
-sinon@^9.2.4:
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.2.4.tgz#e55af4d3b174a4443a8762fa8421c2976683752b"
-  integrity sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   dependencies:
-    "@sinonjs/commons" "^1.8.1"
-    "@sinonjs/fake-timers" "^6.0.1"
-    "@sinonjs/samsam" "^5.3.1"
-    diff "^4.0.2"
-    nise "^4.0.4"
-    supports-color "^7.1.0"
+    shebang-regex "^3.0.0"
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+signal-exit@^3.0.2:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.6.tgz#24e630c4b0f03fea446a2bd299e62b4a6ca8d0af"
+  integrity sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==
+
+signal-exit@^3.0.3:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
+  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+sinon@^13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-13.0.1.tgz#2a568beca2084c48985dd98e276e065c81738e3c"
+  integrity sha512-8yx2wIvkBjIq/MGY1D9h1LMraYW+z1X0mb648KZnKSdvLasvDu7maa0dFaNYdTDczFgbjNw2tOmWdTk9saVfwQ==
+  dependencies:
+    "@sinonjs/commons" "^1.8.3"
+    "@sinonjs/fake-timers" "^9.0.0"
+    "@sinonjs/samsam" "^6.1.1"
+    diff "^5.0.0"
+    nise "^5.1.1"
+    supports-color "^7.2.0"
 
 slash@^3.0.0:
   version "3.0.0"
-  resolved "https://npm.dev.jogogo.co/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-slice-ansi@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787"
-  integrity sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==
+slash@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
+  integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
+
+slice-ansi@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-5.0.0.tgz#b73063c57aa96f9cd881654b15294d95d285c42a"
+  integrity sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==
   dependencies:
-    ansi-styles "^4.0.0"
-    astral-regex "^2.0.0"
-    is-fullwidth-code-point "^3.0.0"
-
-source-map-support@^0.5.17, source-map-support@^0.5.19:
-  version "0.5.19"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
-  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
-source-map@^0.6.0:
-  version "0.6.1"
-  resolved "https://npm.dev.jogogo.co/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-spdx-correct@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
-  integrity sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==
-  dependencies:
-    spdx-expression-parse "^3.0.0"
-    spdx-license-ids "^3.0.0"
-
-spdx-exceptions@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz#2ea450aee74f2a89bfb94519c07fcd6f41322977"
-  integrity sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==
-
-spdx-expression-parse@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
-  integrity sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==
-  dependencies:
-    spdx-exceptions "^2.1.0"
-    spdx-license-ids "^3.0.0"
-
-spdx-license-ids@^3.0.0:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
-  integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
+    ansi-styles "^6.0.0"
+    is-fullwidth-code-point "^4.0.0"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
-  resolved "https://npm.dev.jogogo.co/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stack-utils@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.3.tgz#cd5f030126ff116b78ccb3c027fe302713b61277"
-  integrity sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
+stack-utils@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.5.tgz#d25265fca995154659dbbfba3b49254778d2fdd5"
+  integrity sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==
   dependencies:
     escape-string-regexp "^2.0.0"
 
-string-width@^3.0.0:
-  version "3.1.0"
-  resolved "https://npm.dev.jogogo.co/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
-  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
-  dependencies:
-    emoji-regex "^7.0.1"
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^5.1.0"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
-  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   dependencies:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.0"
+    strip-ansi "^6.0.1"
 
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+string-width@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.0.tgz#5ab00980cfb29f43e736b113a120a73a0fb569d3"
+  integrity sha512-7x54QnN21P+XL/v8SuNKvfgsUre6PXpN7mc77N3HlZv+f1SBRGmjxtOud2Z6FZ8DmdkD/IdjCaf9XXbnqmTZGQ==
   dependencies:
-    safe-buffer "~5.2.0"
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
 
-strip-ansi@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
-  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
-    ansi-regex "^4.1.0"
+    ansi-regex "^5.0.1"
 
-strip-ansi@^6.0.0:
-  version "6.0.0"
-  resolved "https://npm.dev.jogogo.co/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
-  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+strip-ansi@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.0.1.tgz#61740a08ce36b61e50e65653f07060d000975fb2"
+  integrity sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==
   dependencies:
-    ansi-regex "^5.0.0"
+    ansi-regex "^6.0.1"
 
-strip-bom@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
-  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
-
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+strip-final-newline@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
 stromjs@./:
-  version "0.5.1"
+  version "0.5.2"
 
 supertap@^2.0.0:
   version "2.0.0"
@@ -1965,12 +1463,12 @@ supertap@^2.0.0:
 
 supports-color@^5.3.0:
   version "5.5.0"
-  resolved "https://npm.dev.jogogo.co/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.1.0:
+supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -1987,44 +1485,36 @@ time-zone@^1.0.0:
   resolved "https://registry.yarnpkg.com/time-zone/-/time-zone-1.0.0.tgz#99c5bf55958966af6d06d83bdf3800dc82faec5d"
   integrity sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=
 
-to-readable-stream@^1.0.0:
-  version "1.0.0"
-  resolved "https://npm.dev.jogogo.co/to-readable-stream/-/to-readable-stream-1.0.0.tgz#ce0aa0c2f3df6adf852efb404a783e77c0475771"
-  integrity sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==
-
 to-regex-range@^5.0.1:
   version "5.0.1"
-  resolved "https://npm.dev.jogogo.co/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
 
-trim-off-newlines@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
-  integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
-
-ts-node@^9.1.1:
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
-  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+ts-node@^10.5.0:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.5.0.tgz#618bef5854c1fbbedf5e31465cbb224a1d524ef9"
+  integrity sha512-6kEJKwVxAJ35W4akuiysfKwKmjkbYxwQMTBaAxo9KKAx/Yd26mPUyhGz3ji+EsJoAgrLqVsYHNuuYwQe22lbtw==
   dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
     arg "^4.1.0"
     create-require "^1.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
-    source-map-support "^0.5.17"
+    v8-compile-cache-lib "^3.0.0"
     yn "3.1.1"
 
-tslib@^1.13.0:
+tslib@^1.13.0, tslib@^1.7.1, tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^1.7.1, tslib@^1.8.1:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
-  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 tslint-config-prettier@^1.16.0:
   version "1.18.0"
@@ -2061,7 +1551,7 @@ tslint@^6.1.3:
 
 tsutils@^2.29.0:
   version "2.29.0"
-  resolved "https://npm.dev.jogogo.co/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
   integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
   dependencies:
     tslib "^1.8.1"
@@ -2076,98 +1566,34 @@ type-fest@^0.13.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
   integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
 
-type-fest@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
-  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
-
-type-fest@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
-  integrity sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==
-
-type-fest@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
-  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
-
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
-  resolved "https://npm.dev.jogogo.co/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@^4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
-unique-string@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"
-  integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
-  dependencies:
-    crypto-random-string "^2.0.0"
-
-update-notifier@^5.0.1:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-5.1.0.tgz#4ab0d7c7f36a231dd7316cf7729313f0214d9ad9"
-  integrity sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==
-  dependencies:
-    boxen "^5.0.0"
-    chalk "^4.1.0"
-    configstore "^5.0.1"
-    has-yarn "^2.1.0"
-    import-lazy "^2.1.0"
-    is-ci "^2.0.0"
-    is-installed-globally "^0.4.0"
-    is-npm "^5.0.0"
-    is-yarn-global "^0.3.0"
-    latest-version "^5.1.0"
-    pupa "^2.1.1"
-    semver "^7.3.4"
-    semver-diff "^3.1.1"
-    xdg-basedir "^4.0.0"
-
-url-parse-lax@^3.0.0:
+v8-compile-cache-lib@^3.0.0:
   version "3.0.0"
-  resolved "https://npm.dev.jogogo.co/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
-  integrity sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
-  dependencies:
-    prepend-http "^2.0.0"
-
-util-deprecate@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
-
-validate-npm-package-license@^3.0.1:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
-  integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
-  dependencies:
-    spdx-correct "^3.0.0"
-    spdx-expression-parse "^3.0.0"
-
-wcwidth@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
-  integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
-  dependencies:
-    defaults "^1.0.3"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz#0582bcb1c74f3a2ee46487ceecf372e46bce53e8"
+  integrity sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==
 
 well-known-symbols@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/well-known-symbols/-/well-known-symbols-2.0.0.tgz#e9c7c07dbd132b7b84212c8174391ec1f9871ba5"
   integrity sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==
 
-widest-line@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-3.1.0.tgz#8292333bbf66cb45ff0de1603b136b7ae1496eca"
-  integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
-    string-width "^4.0.0"
+    isexe "^2.0.0"
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
@@ -2180,18 +1606,8 @@ wrap-ansi@^7.0.0:
 
 wrappy@1:
   version "1.0.2"
-  resolved "https://npm.dev.jogogo.co/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
-
-write-file-atomic@^3.0.0:
-  version "3.0.1"
-  resolved "https://npm.dev.jogogo.co/write-file-atomic/-/write-file-atomic-3.0.1.tgz#558328352e673b5bb192cf86500d60b230667d4b"
-  integrity sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==
-  dependencies:
-    imurmurhash "^0.1.4"
-    is-typedarray "^1.0.0"
-    signal-exit "^3.0.2"
-    typedarray-to-buffer "^3.1.5"
 
 write-file-atomic@^3.0.3:
   version "3.0.3"
@@ -2203,40 +1619,40 @@ write-file-atomic@^3.0.3:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-xdg-basedir@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
-  integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
-
 y18n@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
-  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yargs-parser@^20.2.2:
-  version "20.2.4"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
-  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
+yargs-parser@^21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.0.tgz#a485d3966be4317426dd56bdb6a30131b281dc55"
+  integrity sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==
 
-yargs@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
-  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+yargs@^17.3.1:
+  version "17.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.3.1.tgz#da56b28f32e2fd45aefb402ed9c26f42be4c07b9"
+  integrity sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"
     get-caller-file "^2.0.5"
     require-directory "^2.1.1"
-    string-width "^4.2.0"
+    string-width "^4.2.3"
     y18n "^5.0.5"
-    yargs-parser "^20.2.2"
+    yargs-parser "^21.0.0"
 
 yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
+yocto-queue@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
+  integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==


### PR DESCRIPTION
Ava removed `test.cb` so we must wrap all .cb tests with promises.
Skipped tests were made for pipelines that continue functioning after
errors, this is not the default nodejs behavior and we still don't have
that feature available so testing the default behavior makes more sense
for now.